### PR TITLE
Add surprise design generator with undo support

### DIFF
--- a/components/CanvasStage.tsx
+++ b/components/CanvasStage.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image';
 import { useEditorStore } from 'lib/editorStore';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 /**
  * A simple visual representation of the generated Open Graph image. This
@@ -16,6 +16,7 @@ export default function CanvasStage() {
     subtitle,
     theme,
     layout,
+    accentColor,
     bannerUrl,
     logoFile,
     logoPosition,
@@ -43,7 +44,8 @@ export default function CanvasStage() {
 
   return (
     <div
-      className={`relative w-full h-0 pt-[52.5%] overflow-hidden rounded-lg shadow-md border border-gray-200 ${themeClasses}`}
+      className={`relative w-full h-0 pt-[52.5%] overflow-hidden rounded-lg shadow-md border ${themeClasses}`}
+      style={{ borderColor: accentColor }}
     >
       {/* Banner */}
       {bannerUrl && (
@@ -60,7 +62,10 @@ export default function CanvasStage() {
       <div
         className={`absolute inset-0 flex flex-col justify-center px-12 py-8 space-y-4 ${layoutClasses}`}
       >
-        <h1 className="text-3xl md:text-5xl font-bold leading-tight break-words">
+        <h1
+          className="text-3xl md:text-5xl font-bold leading-tight break-words"
+          style={{ color: accentColor }}
+        >
           {title || 'Seu título aqui'}
         </h1>
         <p className="text-lg md:text-2xl max-w-prose">

--- a/components/ExportControls.tsx
+++ b/components/ExportControls.tsx
@@ -2,6 +2,8 @@
 
 import { useEditorStore } from 'lib/editorStore';
 import { useSession } from 'next-auth/react';
+import { useState } from 'react';
+import { generateRandomStyle, type RandomStyle } from 'lib/randomStyle';
 
 /**
  * Buttons to export the generated Open Graph image and copy the associated
@@ -9,8 +11,9 @@ import { useSession } from 'next-auth/react';
  * is left as a TODO for future sprints.
  */
 export default function ExportControls() {
-  const { title, subtitle } = useEditorStore();
+  const { title, subtitle, theme, layout, accentColor, setTheme, setLayout, setAccentColor } = useEditorStore();
   const { data: session } = useSession();
+  const [prevStyle, setPrevStyle] = useState<RandomStyle | null>(null);
 
   const handleCopyMeta = async () => {
     const tags = [
@@ -35,7 +38,19 @@ export default function ExportControls() {
   };
 
   const handleSurprise = () => {
-    alert('Funcionalidade “Surpreenda-me” não implementada ainda.');
+    setPrevStyle({ theme, layout, accentColor });
+    const random = generateRandomStyle();
+    setTheme(random.theme);
+    setLayout(random.layout);
+    setAccentColor(random.accentColor);
+  };
+
+  const handleUndo = () => {
+    if (!prevStyle) return;
+    setTheme(prevStyle.theme);
+    setLayout(prevStyle.layout);
+    setAccentColor(prevStyle.accentColor);
+    setPrevStyle(null);
   };
 
   return (
@@ -58,6 +73,14 @@ export default function ExportControls() {
       >
         Surpreenda‑me
       </button>
+      {prevStyle && (
+        <button
+          onClick={handleUndo}
+          className="rounded-md bg-yellow-500 px-4 py-2 text-sm font-medium text-white hover:bg-yellow-600"
+        >
+          Desfazer
+        </button>
+      )}
     </div>
   );
 }

--- a/lib/editorStore.ts
+++ b/lib/editorStore.ts
@@ -11,6 +11,7 @@ export interface EditorState {
   subtitle: string;
   theme: 'light' | 'dark';
   layout: 'left' | 'center';
+  accentColor: string;
   bannerUrl?: string;
   logoFile?: File;
   logoPosition: { x: number; y: number };
@@ -22,6 +23,7 @@ export interface EditorState {
   setSubtitle: (value: string) => void;
   setTheme: (value: 'light' | 'dark') => void;
   setLayout: (value: 'left' | 'center') => void;
+  setAccentColor: (value: string) => void;
   setBannerUrl: (value: string | undefined) => void;
   setLogoFile: (file: File | undefined) => void;
   setLogoPosition: (x: number, y: number) => void;
@@ -35,6 +37,7 @@ export const useEditorStore = create<EditorState>((set) => ({
   subtitle: '',
   theme: 'light',
   layout: 'left',
+  accentColor: '#3b82f6',
   logoPosition: { x: 0, y: 0 },
   logoScale: 1,
   invertLogo: false,
@@ -43,6 +46,7 @@ export const useEditorStore = create<EditorState>((set) => ({
   setSubtitle: (value) => set({ subtitle: value }),
   setTheme: (value) => set({ theme: value }),
   setLayout: (value) => set({ layout: value }),
+  setAccentColor: (value) => set({ accentColor: value }),
   setBannerUrl: (value) => set({ bannerUrl: value }),
   setLogoFile: (file) => set({ logoFile: file }),
   setLogoPosition: (x, y) => set({ logoPosition: { x, y } }),

--- a/lib/randomStyle.ts
+++ b/lib/randomStyle.ts
@@ -1,0 +1,24 @@
+export interface RandomStyle {
+  theme: 'light' | 'dark';
+  layout: 'left' | 'center';
+  accentColor: string;
+}
+
+const themes: RandomStyle['theme'][] = ['light', 'dark'];
+const layouts: RandomStyle['layout'][] = ['left', 'center'];
+// A handful of pleasant accent colors
+const colors: string[] = [
+  '#3b82f6', // blue
+  '#ef4444', // red
+  '#22c55e', // green
+  '#f59e0b', // amber
+  '#a855f7', // purple
+  '#ec4899' // pink
+];
+
+export function generateRandomStyle(): RandomStyle {
+  const theme = themes[Math.floor(Math.random() * themes.length)];
+  const layout = layouts[Math.floor(Math.random() * layouts.length)];
+  const accentColor = colors[Math.floor(Math.random() * colors.length)];
+  return { theme, layout, accentColor };
+}


### PR DESCRIPTION
## Summary
- add random style utility to generate theme, layout, and accent color combinations
- integrate "Surpreenda‑me" button to apply random styles and allow undo
- render accent color in canvas for preview

## Testing
- `npm test` (fails: Missing script "test")
- `pnpm lint` (fails: next lint requires configuration)

------
https://chatgpt.com/codex/tasks/task_e_68a946fc2848832b949b3fa6a466bb03