### PR TITLE
feat: add image editing features

### DIFF
--- a/components/CanvasStage.tsx
+++ b/components/CanvasStage.tsx
@@ -3,6 +3,8 @@
 import Image from 'next/image';
 import { useEditorStore } from 'lib/editorStore';
 import { useEffect, useState } from 'react';
+import { invertImageColors, blobToDataURL } from 'lib/images';
+import { removeImageBackground } from 'lib/removeBg';
 
 /**
  * A simple visual representation of the generated Open Graph image. This
@@ -19,24 +21,55 @@ export default function CanvasStage() {
     accentColor,
     bannerUrl,
     logoFile,
+    logoUrl,
     logoPosition,
     logoScale,
-    invertLogo
+    invertLogo,
+    removeLogoBg,
+    maskLogo
   } = useEditorStore();
   const [logoDataUrl, setLogoDataUrl] = useState<string | undefined>(undefined);
 
-  // Convert uploaded logo file into data URL for display
+  // Prepare logo image applying optional background removal and inversion
   useEffect(() => {
-    if (logoFile) {
-      const reader = new FileReader();
-      reader.onload = () => {
-        setLogoDataUrl(reader.result as string);
-      };
-      reader.readAsDataURL(logoFile);
-      return () => reader.abort();
-    }
-    setLogoDataUrl(undefined);
-  }, [logoFile]);
+    let cancelled = false;
+    const process = async () => {
+      let source: string | Blob | undefined;
+      if (logoFile) {
+        source = logoFile;
+      } else if (logoUrl) {
+        source = logoUrl;
+      } else {
+        setLogoDataUrl(undefined);
+        return;
+      }
+
+      try {
+        if (removeLogoBg) {
+          source = await removeImageBackground(source);
+        } else if (source instanceof Blob) {
+          source = await blobToDataURL(source);
+        }
+
+        if (invertLogo && typeof source === 'string') {
+          source = await invertImageColors(source);
+        }
+
+        if (!cancelled) {
+          setLogoDataUrl(source as string);
+        }
+      } catch (e) {
+        console.error(e);
+        if (!cancelled) {
+          setLogoDataUrl(undefined);
+        }
+      }
+    };
+    process();
+    return () => {
+      cancelled = true;
+    };
+  }, [logoFile, logoUrl, removeLogoBg, invertLogo]);
 
   // Determine CSS classes for themes and layout
   const themeClasses = theme === 'dark' ? 'bg-gray-900 text-white' : 'bg-white text-gray-900';
@@ -81,8 +114,7 @@ export default function CanvasStage() {
           style={{
             top: `${logoPosition.y}%`,
             left: `${logoPosition.x}%`,
-            transform: `translate(-50%, -50%) scale(${logoScale})`,
-            filter: invertLogo ? 'invert(1)' : undefined
+            transform: `translate(-50%, -50%) scale(${logoScale})`
           }}
         >
           {/* We ignore type errors because Next.js <Image> requires fixed width/height or fill. */}
@@ -90,7 +122,7 @@ export default function CanvasStage() {
           <img
             src={logoDataUrl}
             alt="Logo"
-            className="object-contain w-24 h-24 rounded-full shadow"
+            className={`object-contain w-24 h-24 ${maskLogo ? 'rounded-full' : ''} shadow`}
           />
         </div>
       )}

--- a/components/EditorControls.tsx
+++ b/components/EditorControls.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChangeEvent } from 'react';
+import { ChangeEvent, DragEvent } from 'react';
 import { useEditorStore } from 'lib/editorStore';
 
 /**
@@ -14,20 +14,25 @@ export default function EditorControls() {
     subtitle,
     theme,
     layout,
+    bannerUrl,
     logoPosition,
     logoScale,
     invertLogo,
     removeLogoBg,
+    logoUrl,
+    maskLogo,
     setTitle,
     setSubtitle,
     setTheme,
     setLayout,
     setBannerUrl,
     setLogoFile,
+    setLogoUrl,
     setLogoPosition,
     setLogoScale,
     toggleInvertLogo,
-    toggleRemoveLogoBg
+    toggleRemoveLogoBg,
+    toggleMaskLogo
   } = useEditorStore();
 
   const handleBannerChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -47,6 +52,33 @@ export default function EditorControls() {
       return;
     }
     setLogoFile(file);
+  };
+
+  const handleBannerUrlChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const url = e.target.value;
+    setBannerUrl(url || undefined);
+  };
+
+  const handleLogoUrlChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const url = e.target.value;
+    setLogoUrl(url || undefined);
+  };
+
+  const handleBannerDrop = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files?.[0];
+    if (file) {
+      const url = URL.createObjectURL(file);
+      setBannerUrl(url);
+    }
+  };
+
+  const handleLogoDrop = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files?.[0];
+    if (file) {
+      setLogoFile(file);
+    }
   };
 
   return (
@@ -107,7 +139,7 @@ export default function EditorControls() {
           </select>
         </div>
       </div>
-      <div>
+      <div onDragOver={(e) => e.preventDefault()} onDrop={handleBannerDrop}>
         <label className="block text-sm font-medium text-gray-700" htmlFor="banner">
           Banner (opcional)
         </label>
@@ -118,10 +150,17 @@ export default function EditorControls() {
           onChange={handleBannerChange}
           className="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:rounded-md file:border-0 file:bg-gray-100 file:py-2 file:px-4 file:text-sm file:font-semibold file:text-gray-700 hover:file:bg-gray-200"
         />
+        <input
+          type="url"
+          placeholder="URL do banner"
+          value={bannerUrl || ''}
+          onChange={handleBannerUrlChange}
+          className="mt-2 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+        />
       </div>
-      <div>
+      <div onDragOver={(e) => e.preventDefault()} onDrop={handleLogoDrop}>
         <label className="block text-sm font-medium text-gray-700" htmlFor="logo">
-          Logo (upload)
+          Logo (upload ou URL)
         </label>
         <input
           id="logo"
@@ -129,6 +168,13 @@ export default function EditorControls() {
           accept="image/*"
           onChange={handleLogoChange}
           className="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:rounded-md file:border-0 file:bg-gray-100 file:py-2 file:px-4 file:text-sm file:font-semibold file:text-gray-700 hover:file:bg-gray-200"
+        />
+        <input
+          type="url"
+          placeholder="URL do logo"
+          value={logoUrl || ''}
+          onChange={handleLogoUrlChange}
+          className="mt-2 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
         />
       </div>
       <div className="flex space-x-4">
@@ -196,6 +242,15 @@ export default function EditorControls() {
             className="rounded border-gray-300 text-blue-600 shadow-sm focus:border-blue-500 focus:ring-blue-500"
           />
           <span>Remover fundo do logo</span>
+        </label>
+        <label className="flex items-center space-x-2 text-sm">
+          <input
+            type="checkbox"
+            checked={maskLogo}
+            onChange={toggleMaskLogo}
+            className="rounded border-gray-300 text-blue-600 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+          />
+          <span>Máscara circular</span>
         </label>
       </div>
     </div>

--- a/lib/editorStore.ts
+++ b/lib/editorStore.ts
@@ -14,10 +14,12 @@ export interface EditorState {
   accentColor: string;
   bannerUrl?: string;
   logoFile?: File;
+  logoUrl?: string;
   logoPosition: { x: number; y: number };
   logoScale: number;
   invertLogo: boolean;
   removeLogoBg: boolean;
+  maskLogo: boolean;
   // actions
   setTitle: (value: string) => void;
   setSubtitle: (value: string) => void;
@@ -26,10 +28,12 @@ export interface EditorState {
   setAccentColor: (value: string) => void;
   setBannerUrl: (value: string | undefined) => void;
   setLogoFile: (file: File | undefined) => void;
+  setLogoUrl: (url: string | undefined) => void;
   setLogoPosition: (x: number, y: number) => void;
   setLogoScale: (scale: number) => void;
   toggleInvertLogo: () => void;
   toggleRemoveLogoBg: () => void;
+  toggleMaskLogo: () => void;
 }
 
 export const useEditorStore = create<EditorState>((set) => ({
@@ -42,15 +46,18 @@ export const useEditorStore = create<EditorState>((set) => ({
   logoScale: 1,
   invertLogo: false,
   removeLogoBg: false,
+  maskLogo: false,
   setTitle: (value) => set({ title: value }),
   setSubtitle: (value) => set({ subtitle: value }),
   setTheme: (value) => set({ theme: value }),
   setLayout: (value) => set({ layout: value }),
   setAccentColor: (value) => set({ accentColor: value }),
   setBannerUrl: (value) => set({ bannerUrl: value }),
-  setLogoFile: (file) => set({ logoFile: file }),
+  setLogoFile: (file) => set({ logoFile: file, logoUrl: undefined }),
+  setLogoUrl: (url) => set({ logoUrl: url, logoFile: undefined }),
   setLogoPosition: (x, y) => set({ logoPosition: { x, y } }),
   setLogoScale: (scale) => set({ logoScale: scale }),
   toggleInvertLogo: () => set((state) => ({ invertLogo: !state.invertLogo })),
-  toggleRemoveLogoBg: () => set((state) => ({ removeLogoBg: !state.removeLogoBg }))
+  toggleRemoveLogoBg: () => set((state) => ({ removeLogoBg: !state.removeLogoBg })),
+  toggleMaskLogo: () => set((state) => ({ maskLogo: !state.maskLogo }))
 }));

--- a/lib/images.ts
+++ b/lib/images.ts
@@ -29,3 +29,50 @@ export async function exportElementAsPng(
   link.href = dataUrl;
   link.click();
 }
+
+/**
+ * Convert a Blob into a base64 data URL string.
+ */
+export function blobToDataURL(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(reader.result as string);
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+}
+
+/**
+ * Invert all colors of an image represented by a data URL.
+ *
+ * @param dataUrl base64 encoded image source
+ * @returns data URL of the inverted image
+ */
+export async function invertImageColors(dataUrl: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = img.width;
+      canvas.height = img.height;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        reject(new Error('Failed to obtain canvas context'));
+        return;
+      }
+      ctx.drawImage(img, 0, 0);
+      const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+      const data = imageData.data;
+      for (let i = 0; i < data.length; i += 4) {
+        data[i] = 255 - data[i];
+        data[i + 1] = 255 - data[i + 1];
+        data[i + 2] = 255 - data[i + 2];
+      }
+      ctx.putImageData(imageData, 0, 0);
+      resolve(canvas.toDataURL());
+    };
+    img.onerror = reject;
+    img.src = dataUrl;
+  });
+}

--- a/lib/removeBg.ts
+++ b/lib/removeBg.ts
@@ -1,0 +1,13 @@
+import removeBackground from '@imgly/background-removal';
+import { blobToDataURL } from './images';
+
+/**
+ * Remove the background of an image using @imgly/background-removal.
+ *
+ * @param source File, Blob, or URL string pointing to an image
+ * @returns A base64 data URL of the processed image
+ */
+export async function removeImageBackground(source: Blob | string): Promise<string> {
+  const blob = await removeBackground(source);
+  return blobToDataURL(blob);
+}

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@imgly/background-removal": "^1.7.0",
     "@tailwindcss/forms": "^0.5.10",
     "autoprefixer": "^10.4.14",
     "html-to-image": "^1.11.13",
     "next": "15.5.0",
     "next-auth": "^4.24.11",
+    "onnxruntime-web": "1.21.0-dev.20250206-d981b153d3",
     "postcss": "^8.4.23",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@imgly/background-removal':
+        specifier: ^1.7.0
+        version: 1.7.0(onnxruntime-web@1.21.0-dev.20250206-d981b153d3)
       '@tailwindcss/forms':
         specifier: ^0.5.10
         version: 0.5.10(tailwindcss@3.4.17)
@@ -23,6 +26,9 @@ importers:
       next-auth:
         specifier: ^4.24.11
         version: 4.24.11(next@15.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      onnxruntime-web:
+        specifier: 1.21.0-dev.20250206-d981b153d3
+        version: 1.21.0-dev.20250206-d981b153d3
       postcss:
         specifier: ^8.4.23
         version: 8.5.6
@@ -257,6 +263,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@imgly/background-removal@1.7.0':
+    resolution: {integrity: sha512-/1ZryrMYg2ckIvJKoTu5Np50JfYMVffDMlVmppw/BdbN3pBTN7e6stI5/7E/LVh9DDzz6J588s7sWqul3fy5wA==}
+    peerDependencies:
+      onnxruntime-web: 1.21.0
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -353,6 +364,36 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -1019,6 +1060,9 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
+  flatbuffers@25.2.10:
+    resolution: {integrity: sha512-7JlN9ZvLDG1McO3kbX0k4v+SUAg48L1rIwEvN6ZQl/eCtgJz9UylTMzE9wrmYrcorgxm3CX/3T/w5VAub99UUw==}
+
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
@@ -1090,6 +1134,9 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  guid-typescript@1.0.9:
+    resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -1140,6 +1187,9 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
+  iota-array@1.0.0:
+    resolution: {integrity: sha512-pZ2xT+LOHckCatGQ3DcG/a+QuEqvoxqkiL7tvE8nn3uuu+f6i1TtpB5/FtWFbxUuVr5PZCx8KskuGatbJDXOWA==}
+
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
@@ -1162,6 +1212,9 @@ packages:
   is-boolean-object@1.2.2:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
+
+  is-buffer@1.1.6:
+    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
 
   is-bun-module@2.0.0:
     resolution: {integrity: sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==}
@@ -1323,8 +1376,14 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash-es@4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -1385,6 +1444,9 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  ndarray@1.0.19:
+    resolution: {integrity: sha512-B4JHA4vdyZU30ELBw3g7/p9bZupyew5a7tX1Y/gGeF2hafrPaQZhgrGQfsvgfYbgdFZjYwuEcnaobeM/WMW+HQ==}
 
   next-auth@4.24.11:
     resolution: {integrity: sha512-pCFXzIDQX7xmHFs4KVH4luCjaCbuPRtZ9oBUjUhOk84mZ9WVPf94n87TxYI4rSRf9HmfHEF8Yep3JrYDVOo3Cw==}
@@ -1479,6 +1541,12 @@ packages:
     resolution: {integrity: sha512-D7EmwxJV6DsEB6vOFLrBM2OzsVgQzgPWyHlV2OOAVj772n+WTXpudC9e9u5BVKQnYwaD30Ivhi9b+4UeBcGu9g==}
     engines: {node: ^10.13.0 || >=12.0.0}
 
+  onnxruntime-common@1.21.0-dev.20250206-d981b153d3:
+    resolution: {integrity: sha512-TwaE51xV9q2y8pM61q73rbywJnusw9ivTEHAJ39GVWNZqxCoDBpe/tQkh/w9S+o/g+zS7YeeL0I/2mEWd+dgyA==}
+
+  onnxruntime-web@1.21.0-dev.20250206-d981b153d3:
+    resolution: {integrity: sha512-esDVQdRic6J44VBMFLumYvcGfioMh80ceLmzF1yheJyuLKq/Th8VT2aj42XWQst+2bcWnAhw4IKmRQaqzU8ugg==}
+
   openid-client@5.7.1:
     resolution: {integrity: sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==}
 
@@ -1538,6 +1606,9 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -1605,6 +1676,10 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  protobufjs@7.5.4:
+    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+    engines: {node: '>=12.0.0'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -1954,6 +2029,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zustand@4.5.7:
     resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
     engines: {node: '>=12.7.0'}
@@ -2134,6 +2212,13 @@ snapshots:
   '@img/sharp-win32-x64@0.34.3':
     optional: true
 
+  '@imgly/background-removal@1.7.0(onnxruntime-web@1.21.0-dev.20250206-d981b153d3)':
+    dependencies:
+      lodash-es: 4.17.21
+      ndarray: 1.0.19
+      onnxruntime-web: 1.21.0-dev.20250206-d981b153d3
+      zod: 3.25.76
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -2212,6 +2297,29 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
 
   '@rtsao/scc@1.1.0': {}
 
@@ -3046,6 +3154,8 @@ snapshots:
       flatted: 3.3.3
       keyv: 4.5.4
 
+  flatbuffers@25.2.10: {}
+
   flatted@3.3.3: {}
 
   for-each@0.3.5:
@@ -3131,6 +3241,8 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  guid-typescript@1.0.9: {}
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -3172,6 +3284,8 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.1.0
 
+  iota-array@1.0.0: {}
+
   is-array-buffer@3.0.5:
     dependencies:
       call-bind: 1.0.8
@@ -3201,6 +3315,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+
+  is-buffer@1.1.6: {}
 
   is-bun-module@2.0.0:
     dependencies:
@@ -3361,7 +3477,11 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash-es@4.17.21: {}
+
   lodash.merge@4.6.2: {}
+
+  long@5.3.2: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -3409,6 +3529,11 @@ snapshots:
   napi-postinstall@0.3.3: {}
 
   natural-compare@1.4.0: {}
+
+  ndarray@1.0.19:
+    dependencies:
+      iota-array: 1.0.0
+      is-buffer: 1.1.6
 
   next-auth@4.24.11(next@15.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -3504,6 +3629,17 @@ snapshots:
 
   oidc-token-hash@5.1.1: {}
 
+  onnxruntime-common@1.21.0-dev.20250206-d981b153d3: {}
+
+  onnxruntime-web@1.21.0-dev.20250206-d981b153d3:
+    dependencies:
+      flatbuffers: 25.2.10
+      guid-typescript: 1.0.9
+      long: 5.3.2
+      onnxruntime-common: 1.21.0-dev.20250206-d981b153d3
+      platform: 1.3.6
+      protobufjs: 7.5.4
+
   openid-client@5.7.1:
     dependencies:
       jose: 4.15.9
@@ -3560,6 +3696,8 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
+
+  platform@1.3.6: {}
 
   possible-typed-array-names@1.1.0: {}
 
@@ -3622,6 +3760,21 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  protobufjs@7.5.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 20.19.11
+      long: 5.3.2
 
   punycode@2.3.1: {}
 
@@ -4126,6 +4279,8 @@ snapshots:
   yaml@2.8.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.25.76: {}
 
   zustand@4.5.7(@types/react@18.3.24)(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## Summary
- add blob and color inversion helpers for client-side processing
- integrate @imgly/background-removal for optional logo background removal
- support drag-and-drop, URL uploads and circular masking in editor

## Testing
- `pnpm lint` *(fails: interactive prompt for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a9472c2a6c832baa2fe1d6b2cd1b0e