### PR TITLE
Remove issuer from LinkedIn provider configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ out
 .env.*.local
 dist
 coverage
+tsconfig.tsbuildinfo

--- a/lib/authOptions.ts
+++ b/lib/authOptions.ts
@@ -27,8 +27,7 @@ export const authOptions: NextAuthOptions = {
     LinkedinProvider({
       clientId: process.env.LINKEDIN_CLIENT_ID ?? '',
       clientSecret: process.env.LINKEDIN_CLIENT_SECRET ?? '',
-      issuer: "https://www.linkedin.com/oauth",                 // <- chave do fix
-      authorization: { params: { scope: "openid profile email" } } // OIDC
+      authorization: { params: { scope: "openid profile email" } }
     }),
     TwitterProvider({
       clientId: process.env.TWITTER_CONSUMER_KEY ?? '',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,9 +31,9 @@
     ]
   },
   "include": [
-    "/**/*.ts",
-    "/**/*.tsx",
     "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
     ".next/types/**/*.ts"
   ],
   "exclude": [

--- a/types/modules.d.ts
+++ b/types/modules.d.ts
@@ -1,0 +1,7 @@
+declare module 'html-to-image' {
+  export function toPng(node: HTMLElement, options?: unknown): Promise<string>;
+}
+
+declare module '@imgly/background-removal' {
+  export default function removeBackground(...args: any[]): Promise<any>;
+}

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -2,10 +2,15 @@ import { DefaultSession, DefaultUser } from 'next-auth';
 
 declare module 'next-auth' {
   interface Session {
-    user?: DefaultUser & {
+    user?: DefaultSession['user'] & {
       id?: string;
       provider?: string;
     };
+  }
+
+  interface User extends DefaultUser {
+    id: string;
+    provider?: string;
   }
 }
 


### PR DESCRIPTION
## Summary
- remove custom issuer from LinkedIn provider to avoid missing jwks_uri error
- add NextAuth session typings and update tsconfig to include them
- declare modules for html-to-image and background-removal and ignore tsconfig build info

## Testing
- `npx tsc --noEmit && echo 'tsc passed'`
- `pnpm lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d90985a0832b8ae596a1aa894adc