### PR TITLE
Add presets panel for reusable style configurations

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import CanvasStage from 'components/CanvasStage';
 import EditorControls from 'components/EditorControls';
 import ExportControls from 'components/ExportControls';
 import AuthButtons from 'components/AuthButtons';
+import PresetsPanel from 'components/PresetsPanel';
 import { useSession } from 'next-auth/react';
 
 export default function HomePage() {
@@ -14,7 +15,7 @@ export default function HomePage() {
         <h1 className="text-2xl font-bold">OG Image Studio</h1>
         <AuthButtons />
       </header>
-      <section className="mt-8 grid grid-cols-1 gap-8 md:grid-cols-2">
+      <section className="mt-8 grid grid-cols-1 gap-8 md:grid-cols-3">
         <div>
           <EditorControls />
           <div className="mt-6">
@@ -26,6 +27,9 @@ export default function HomePage() {
           <p className="mt-4 text-xs text-gray-500">
             Faça login para persistir suas criações e desbloquear funcionalidades avançadas.
           </p>
+        </div>
+        <div>
+          <PresetsPanel />
         </div>
       </section>
     </main>

--- a/components/PresetsPanel.tsx
+++ b/components/PresetsPanel.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEditorStore } from 'lib/editorStore';
+import { generateRandomPreset } from 'lib/randomStyle';
+
+/**
+ * Panel that allows creating random style presets and applying them.
+ * Presets are stored in the global editor store so they can be reused
+ * across different sessions in the UI.
+ */
+export default function PresetsPanel() {
+  const { presets, addPreset, applyPreset } = useEditorStore();
+
+  const handleGeneratePreset = () => {
+    const preset = generateRandomPreset();
+    addPreset(preset);
+    applyPreset(preset);
+  };
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-semibold">Presets</h2>
+      <button
+        onClick={handleGeneratePreset}
+        className="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+      >
+        Gerar Preset Aleatório
+      </button>
+      <ul className="space-y-2">
+        {presets.map((preset, index) => (
+          <li key={index}>
+            <button
+              onClick={() => applyPreset(preset)}
+              className="flex w-full items-center justify-between rounded-md border px-2 py-1 text-left hover:bg-gray-50"
+            >
+              <span className="text-sm">
+                {preset.theme} / {preset.layout}
+              </span>
+              <span
+                className="h-4 w-4 rounded"
+                style={{ backgroundColor: preset.accentColor }}
+              />
+            </button>
+          </li>
+        ))}
+        {presets.length === 0 && (
+          <li className="text-sm text-gray-500">Nenhum preset salvo.</li>
+        )}
+      </ul>
+    </div>
+  );
+}

--- a/lib/editorStore.ts
+++ b/lib/editorStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import type { Preset } from './randomStyle';
 
 /**
  * Definition of the editor's state. This store manages the current values of
@@ -20,6 +21,7 @@ export interface EditorState {
   invertLogo: boolean;
   removeLogoBg: boolean;
   maskLogo: boolean;
+  presets: Preset[];
   // actions
   setTitle: (value: string) => void;
   setSubtitle: (value: string) => void;
@@ -34,6 +36,8 @@ export interface EditorState {
   toggleInvertLogo: () => void;
   toggleRemoveLogoBg: () => void;
   toggleMaskLogo: () => void;
+  addPreset: (preset: Preset) => void;
+  applyPreset: (preset: Preset) => void;
 }
 
 export const useEditorStore = create<EditorState>((set) => ({
@@ -47,6 +51,7 @@ export const useEditorStore = create<EditorState>((set) => ({
   invertLogo: false,
   removeLogoBg: false,
   maskLogo: false,
+  presets: [],
   setTitle: (value) => set({ title: value }),
   setSubtitle: (value) => set({ subtitle: value }),
   setTheme: (value) => set({ theme: value }),
@@ -59,5 +64,13 @@ export const useEditorStore = create<EditorState>((set) => ({
   setLogoScale: (scale) => set({ logoScale: scale }),
   toggleInvertLogo: () => set((state) => ({ invertLogo: !state.invertLogo })),
   toggleRemoveLogoBg: () => set((state) => ({ removeLogoBg: !state.removeLogoBg })),
-  toggleMaskLogo: () => set((state) => ({ maskLogo: !state.maskLogo }))
+  toggleMaskLogo: () => set((state) => ({ maskLogo: !state.maskLogo })),
+  addPreset: (preset) =>
+    set((state) => ({ presets: [...state.presets, preset] })),
+  applyPreset: (preset) =>
+    set({
+      theme: preset.theme,
+      layout: preset.layout,
+      accentColor: preset.accentColor
+    })
 }));

--- a/lib/randomStyle.ts
+++ b/lib/randomStyle.ts
@@ -4,6 +4,10 @@ export interface RandomStyle {
   accentColor: string;
 }
 
+// A preset is simply a named random style configuration. Keeping an alias
+// makes the intent clearer when used elsewhere in the app.
+export type Preset = RandomStyle;
+
 const themes: RandomStyle['theme'][] = ['light', 'dark'];
 const layouts: RandomStyle['layout'][] = ['left', 'center'];
 // A handful of pleasant accent colors
@@ -21,4 +25,9 @@ export function generateRandomStyle(): RandomStyle {
   const layout = layouts[Math.floor(Math.random() * layouts.length)];
   const accentColor = colors[Math.floor(Math.random() * colors.length)];
   return { theme, layout, accentColor };
+}
+
+// Convenience wrapper with a more semantic name when generating presets.
+export function generateRandomPreset(): Preset {
+  return generateRandomStyle();
 }


### PR DESCRIPTION
## Summary
- add PresetsPanel component to generate, list and apply style presets
- extend editor store with preset state and actions
- include presets panel in main page layout and expose helper in randomStyle

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Command failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68aa05917a60832b95861348e6fcd85b