### PR TITLE
fix: use named removeBackground import

### DIFF
--- a/lib/removeBg.ts
+++ b/lib/removeBg.ts
@@ -1,4 +1,4 @@
-import removeBackground from '@imgly/background-removal';
+import { removeBackground } from "@imgly/background-removal";
 import { blobToDataURL } from './images';
 
 /**
@@ -8,6 +8,17 @@ import { blobToDataURL } from './images';
  * @returns A base64 data URL of the processed image
  */
 export async function removeImageBackground(source: Blob | string): Promise<string> {
+  if (typeof crossOriginIsolated !== "undefined" && !crossOriginIsolated) {
+    try {
+      Object.defineProperty(navigator, "hardwareConcurrency", {
+        configurable: true,
+        get: () => 1,
+      });
+    } catch {
+      // ignore inability to override
+    }
+  }
+
   const blob = await removeBackground(source);
   return blobToDataURL(blob);
 }

--- a/types/modules.d.ts
+++ b/types/modules.d.ts
@@ -3,5 +3,5 @@ declare module 'html-to-image' {
 }
 
 declare module '@imgly/background-removal' {
-  export default function removeBackground(...args: any[]): Promise<any>;
+  export function removeBackground(...args: any[]): Promise<any>;
 }


### PR DESCRIPTION
## Summary
- switch background removal helper to named import
- force single-threaded wasm when cross-origin isolation is missing

## Testing
- `pnpm test` *(fails: jest: not found)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a9dddb6918832b8939548a0fdb6aee