### PR TITLE
Add environment template for auth provider setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,29 @@
+# Example environment variables for OG Image Generator
+# Copy to .env.local and replace with your credentials.
+
+NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_SECRET=your-nextauth-secret
+
+# Google OAuth
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+
+# GitHub OAuth
+GITHUB_CLIENT_ID=your-github-client-id
+GITHUB_CLIENT_SECRET=your-github-client-secret
+
+# LinkedIn OAuth
+LINKEDIN_CLIENT_ID=your-linkedin-client-id
+LINKEDIN_CLIENT_SECRET=your-linkedin-client-secret
+
+# Twitter OAuth
+TWITTER_CONSUMER_KEY=your-twitter-consumer-key
+TWITTER_CONSUMER_SECRET=your-twitter-consumer-secret
+
+# Facebook OAuth
+FACEBOOK_CLIENT_ID=your-facebook-client-id
+FACEBOOK_CLIENT_SECRET=your-facebook-client-secret
+
+# Instagram OAuth
+INSTAGRAM_CLIENT_ID=your-instagram-client-id
+INSTAGRAM_CLIENT_SECRET=your-instagram-client-secret

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Este repositório contém o esqueleto do **OG Image Studio**, uma aplicação Ne
 
 ## Configuração de Autenticação
 
+O repositório inclui um arquivo `.env.example` que lista todas as variáveis de ambiente necessárias para os provedores de autenticação. Use-o como modelo para criar seu `.env.local`.
+
 1. Copie o arquivo `.env.example` para `.env.local`:
 
    ```bash
@@ -43,7 +45,7 @@ Este repositório contém o esqueleto do **OG Image Studio**, uma aplicação Ne
   - `editorStore.ts`: estado global do editor utilizando Zustand.
 - `types/next-auth.d.ts`: estende os tipos do NextAuth para incluir `id` e `provider` na sessão.
 - `tailwind.config.ts` e `postcss.config.js`: configuração do Tailwind.
-- `.env.example`: exemplo de variáveis de ambiente necessárias.
+- `.env.example`: exemplo de variáveis de ambiente necessárias; copie para `.env.local` e preencha com suas credenciais.
 
 ## Próximos Passos
 


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholders for NextAuth provider keys
- document copying the example to `.env.local` in README

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68aab1a7fe8c832b920c17b59200a390