### PR TITLE
feat: add metadata scraping

### DIFF
--- a/__tests__/api.scrape.route.test.ts
+++ b/__tests__/api.scrape.route.test.ts
@@ -1,0 +1,35 @@
+import { scrape, pickBestImage } from '@odeconto/scraper';
+
+jest.mock('next/server', () => ({
+  NextResponse: { json: (body: any) => ({ json: async () => body }) }
+}));
+
+jest.mock('@odeconto/scraper', () => ({
+  scrape: jest.fn(async () => ({
+    meta: {
+      og: { title: 'Example Title' },
+      twitter: {},
+      basic: { favicon: 'https://example.com/favicon.ico' },
+      fallback: {}
+    },
+    diagnostics: { warnings: ['warn'], source: {}, timingsMs: { fetch: 0, parse: 0 } }
+  })),
+  pickBestImage: jest.fn(() => 'https://example.com/image.png')
+}));
+
+describe('GET /api/scrape', () => {
+  it('returns scraped metadata', async () => {
+    const { GET } = await import('../app/api/scrape/route');
+    const req = { url: 'http://localhost/api/scrape?url=https://example.com' } as Request;
+    const res = await GET(req);
+    const data = await res.json();
+    expect(data).toEqual({
+      title: 'Example Title',
+      image: 'https://example.com/image.png',
+      favicon: 'https://example.com/favicon.ico',
+      warnings: ['warn']
+    });
+    expect(scrape).toHaveBeenCalledWith('https://example.com');
+    expect(pickBestImage).toHaveBeenCalled();
+  });
+});

--- a/__tests__/metadata-panel.test.tsx
+++ b/__tests__/metadata-panel.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import MetadataPanel from '../components/MetadataPanel';
+import { useMetadataStore } from '../lib/metadataStore';
+
+describe('MetadataPanel', () => {
+  beforeEach(() => {
+    useMetadataStore.setState({
+      description: '',
+      image: '',
+      favicon: '',
+      siteName: '',
+      sourceMap: {},
+      warnings: []
+    });
+  });
+
+  afterEach(() => {
+    // @ts-expect-error allow cleanup
+    delete global.fetch;
+  });
+
+  it('fetches metadata and populates the form', async () => {
+    global.fetch = jest.fn(async () => ({
+      json: async () => ({
+        title: 'Example Title',
+        image: 'https://example.com/image.png',
+        favicon: 'https://example.com/favicon.ico',
+        warnings: ['a warning']
+      })
+    })) as any;
+
+    render(<MetadataPanel />);
+
+    fireEvent.change(screen.getByLabelText(/^url$/i), { target: { value: 'https://example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: /fetch metadata/i }));
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Example Title')).toBeInTheDocument();
+    });
+    expect(screen.getByDisplayValue('https://example.com/image.png')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('https://example.com/favicon.ico')).toBeInTheDocument();
+    expect(await screen.findByText('a warning')).toBeInTheDocument();
+  });
+});

--- a/app/api/scrape/route.ts
+++ b/app/api/scrape/route.ts
@@ -1,0 +1,20 @@
+import { scrape, pickBestImage } from '@odeconto/scraper';
+import { NextResponse } from 'next/server';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const target = searchParams.get('url');
+  if (!target) {
+    return NextResponse.json({ error: 'Missing url' }, { status: 400 });
+  }
+  try {
+    const result = await scrape(target);
+    const title = result.meta.og.title ?? result.meta.twitter.title ?? result.meta.basic.title ?? '';
+    const image = pickBestImage(result.meta) || '';
+    const favicon = result.meta.basic.favicon ?? '';
+    const warnings = result.diagnostics.warnings ?? [];
+    return NextResponse.json({ title, image, favicon, warnings });
+  } catch (err: any) {
+    return NextResponse.json({ error: err?.message || 'Failed to scrape' }, { status: 500 });
+  }
+}

--- a/components/MetadataPanel.tsx
+++ b/components/MetadataPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from 'react';
 import { useMetadataStore } from 'lib/metadataStore';
 
 /**
@@ -8,6 +9,7 @@ import { useMetadataStore } from 'lib/metadataStore';
  * architecture where metadata can evolve independently from visual settings.
  */
 export default function MetadataPanel() {
+  const [url, setUrl] = useState('');
   const {
     description,
     image,
@@ -17,12 +19,49 @@ export default function MetadataPanel() {
     setDescription,
     setImage,
     setFavicon,
-    setSiteName
+    setSiteName,
+    setWarnings
   } = useMetadataStore();
+
+  async function handleFetch() {
+    if (!url) return;
+    try {
+      const res = await fetch(`/api/scrape?url=${encodeURIComponent(url)}`);
+      const data = await res.json();
+      setSiteName(data.title || '');
+      setImage(data.image || '');
+      setFavicon(data.favicon || '');
+      setWarnings(data.warnings || []);
+    } catch (err: any) {
+      setWarnings([err?.message || 'Failed to fetch metadata']);
+    }
+  }
 
   return (
     <div className="space-y-4">
       <h2 className="text-lg font-semibold">Metadata</h2>
+      <div>
+        <label className="block text-sm font-medium text-gray-700" htmlFor="url">
+          URL
+        </label>
+        <div className="mt-1 flex gap-2">
+          <input
+            id="url"
+            type="url"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+            placeholder="https://exemplo.com"
+          />
+          <button
+            type="button"
+            onClick={handleFetch}
+            className="rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700"
+          >
+            Fetch metadata
+          </button>
+        </div>
+      </div>
       <div>
         <label className="block text-sm font-medium text-gray-700" htmlFor="siteName">
           Nome do site


### PR DESCRIPTION
## Summary
- add `/api/scrape` route backed by `@odeconto/scraper`
- allow MetadataPanel to fetch metadata from a URL and store results
- cover new API route and panel interactions with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aab1c3cba4832bbf9d0246089fe63c