### PR TITLE
feat: add server background removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Este repositório contém o esqueleto do **OG Image Studio**, uma aplicação Ne
   - `layout.tsx`: carrega estilos globais e injeta o `SessionProvider`.
   - `page.tsx`: página principal com o editor e preview da imagem.
   - `api/auth/[...nextauth]/route.ts`: rota de autenticação do NextAuth.
+  - `api/remove-bg/route.ts`: remove o fundo de uma imagem enviado via POST.
 - `components/`: componentes reutilizáveis.
   - `Providers.tsx`: wrapper com `SessionProvider`.
   - `AuthButtons.tsx`: botões de login/logout.
@@ -44,6 +45,12 @@ Este repositório contém o esqueleto do **OG Image Studio**, uma aplicação Ne
 - `types/next-auth.d.ts`: estende os tipos do NextAuth para incluir `id` e `provider` na sessão.
 - `tailwind.config.ts` e `postcss.config.js`: configuração do Tailwind.
 - `.env.example`: exemplo de variáveis de ambiente necessárias.
+
+## Remoção de fundo
+
+O projeto utiliza a biblioteca `@imgly/background-removal` para eliminar o fundo de logos enviados pelo usuário. Por padrão, o cliente tenta enviar a imagem para a API `POST /api/remove-bg`, que executa a remoção no servidor e retorna a imagem tratada. Caso a rota não esteja disponível ou ocorra algum erro, a operação é realizada no próprio navegador.
+
+A remoção no servidor costuma ser mais rápida e evita limitações de recursos do navegador, porém consome processamento no backend. A execução no cliente reduz a carga do servidor, mas pode ser significativamente mais lenta em dispositivos modestos.
 
 ## Próximos Passos
 

--- a/app/api/remove-bg/route.ts
+++ b/app/api/remove-bg/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { removeBackground } from '@imgly/background-removal';
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  try {
+    const form = await req.formData();
+    const image = form.get('image');
+
+    if (!image) {
+      return NextResponse.json({ error: 'No image provided' }, { status: 400 });
+    }
+
+    const output = await removeBackground(image as any);
+
+    return new NextResponse(output, {
+      headers: {
+        'Content-Type': (output as Blob).type || 'image/png'
+      }
+    });
+  } catch (e) {
+    console.error(e);
+    return NextResponse.json({ error: 'Failed to process image' }, { status: 500 });
+  }
+}

--- a/lib/removeBg.ts
+++ b/lib/removeBg.ts
@@ -2,12 +2,32 @@ import { removeBackground } from "@imgly/background-removal";
 import { blobToDataURL } from './images';
 
 /**
- * Remove the background of an image using @imgly/background-removal.
+ * Remove the background of an image using a preferred method.
+ * Tries the server-side API first when allowed and falls back to
+ * client-side processing.
  *
  * @param source File, Blob, or URL string pointing to an image
+ * @param preferServer Whether to attempt the server API first
  * @returns A base64 data URL of the processed image
  */
-export async function removeImageBackground(source: Blob | string): Promise<string> {
+export async function removeImageBackground(source: Blob | string, preferServer = true): Promise<string> {
+  if (preferServer) {
+    try {
+      const formData = new FormData();
+      formData.append('image', source);
+      const res = await fetch('/api/remove-bg', {
+        method: 'POST',
+        body: formData,
+      });
+      if (res.ok) {
+        const blob = await res.blob();
+        return blobToDataURL(blob);
+      }
+    } catch {
+      // ignore and fall back to client-side path
+    }
+  }
+
   if (typeof crossOriginIsolated !== "undefined" && !crossOriginIsolated) {
     try {
       Object.defineProperty(navigator, "hardwareConcurrency", {


### PR DESCRIPTION
## Summary
- add `/api/remove-bg` route to process images with `@imgly/background-removal`
- prefer server background removal with automatic client fallback
- document background removal workflow and performance tradeoffs

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68aab1e290e4832bac853021d444760e