### PR TITLE
Use bundled scraper types

### DIFF
--- a/__tests__/metadata-panel.test.tsx
+++ b/__tests__/metadata-panel.test.tsx
@@ -15,7 +15,6 @@ describe('MetadataPanel', () => {
   });
 
   afterEach(() => {
-    // @ts-expect-error allow cleanup
     delete global.fetch;
   });
 

--- a/types/modules.d.ts
+++ b/types/modules.d.ts
@@ -6,7 +6,3 @@ declare module '@imgly/background-removal' {
   export function removeBackground(...args: any[]): Promise<any>;
 }
 
-declare module '@odeconto/scraper' {
-  export function scrape(url: string, options?: any): Promise<any>;
-  export function pickBestImage(meta: any): any;
-}


### PR DESCRIPTION
## Summary
- rely on `@odeconto/scraper` bundled TypeScript definitions instead of custom declaration
- remove outdated `@ts-expect-error` in metadata panel test

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68aac1aa3e54832ba417d5b08a3cabcb