### PR TITLE
feat: improve scraper error handling

### DIFF
--- a/__tests__/api.scrape.route.test.ts
+++ b/__tests__/api.scrape.route.test.ts
@@ -1,35 +1,87 @@
 import { scrape, pickBestImage } from '@odeconto/scraper';
 
 jest.mock('next/server', () => ({
-  NextResponse: { json: (body: any) => ({ json: async () => body }) }
+  NextResponse: {
+    json: (body: any, init: any) => ({
+      json: async () => body,
+      status: init?.status,
+    }),
+  },
 }));
 
 jest.mock('@odeconto/scraper', () => ({
-  scrape: jest.fn(async () => ({
-    meta: {
-      og: { title: 'Example Title' },
-      twitter: {},
-      basic: { favicon: 'https://example.com/favicon.ico' },
-      fallback: {}
-    },
-    diagnostics: { warnings: ['warn'], source: {}, timingsMs: { fetch: 0, parse: 0 } }
-  })),
-  pickBestImage: jest.fn(() => 'https://example.com/image.png')
+  scrape: jest.fn(),
+  pickBestImage: jest.fn(),
 }));
 
+const scrapeMock = scrape as jest.Mock;
+const pickBestImageMock = pickBestImage as jest.Mock;
+
 describe('GET /api/scrape', () => {
+  beforeEach(() => {
+    scrapeMock.mockReset();
+    pickBestImageMock.mockReset();
+  });
+
   it('returns scraped metadata', async () => {
+    scrapeMock.mockResolvedValueOnce({
+      meta: {
+        og: { title: 'Example Title' },
+        twitter: {},
+        basic: { favicon: 'https://example.com/favicon.ico' },
+        fallback: {},
+      },
+      diagnostics: {
+        warnings: ['warn'],
+        source: {},
+        timingsMs: { fetch: 0, parse: 0 },
+      },
+    });
+    pickBestImageMock.mockReturnValueOnce('https://example.com/image.png');
+
     const { GET } = await import('../app/api/scrape/route');
-    const req = { url: 'http://localhost/api/scrape?url=https://example.com' } as Request;
+    const req = {
+      url: 'http://localhost/api/scrape?url=https://example.com',
+    } as Request;
     const res = await GET(req);
     const data = await res.json();
     expect(data).toEqual({
       title: 'Example Title',
       image: 'https://example.com/image.png',
       favicon: 'https://example.com/favicon.ico',
-      warnings: ['warn']
+      warnings: ['warn'],
     });
     expect(scrape).toHaveBeenCalledWith('https://example.com');
     expect(pickBestImage).toHaveBeenCalled();
+  });
+
+  it('maps known error codes', async () => {
+    scrapeMock.mockRejectedValueOnce({
+      error: { code: 'ERR_INVALID_URL', message: 'Invalid URL' },
+    });
+
+    const { GET } = await import('../app/api/scrape/route');
+    const req = { url: 'http://localhost/api/scrape?url=bad' } as Request;
+    const res = await GET(req);
+    const data = await res.json();
+    expect(res.status).toBe(400);
+    expect(data).toEqual({
+      error: { code: 'ERR_INVALID_URL', message: 'Invalid URL' },
+    });
+  });
+
+  it('handles unexpected errors', async () => {
+    scrapeMock.mockRejectedValueOnce(new Error('boom'));
+
+    const { GET } = await import('../app/api/scrape/route');
+    const req = {
+      url: 'http://localhost/api/scrape?url=https://example.com',
+    } as Request;
+    const res = await GET(req);
+    const data = await res.json();
+    expect(res.status).toBe(500);
+    expect(data).toEqual({
+      error: { code: 'UNKNOWN', message: 'Internal server error' },
+    });
   });
 });

--- a/app/api/scrape/route.ts
+++ b/app/api/scrape/route.ts
@@ -1,20 +1,75 @@
 import { scrape, pickBestImage } from '@odeconto/scraper';
 import { NextResponse } from 'next/server';
 
+interface ScrapeError {
+  error: {
+    code: string;
+    message: string;
+  };
+}
+
+const ERROR_MAP: Record<string, { status: number; message: string }> = {
+  ERR_INVALID_URL: { status: 400, message: 'Invalid URL' },
+  ENOTFOUND: { status: 404, message: 'Host not found' },
+  ENETUNREACH: { status: 503, message: 'Network unreachable' },
+};
+
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
   const target = searchParams.get('url');
   if (!target) {
-    return NextResponse.json({ error: 'Missing url' }, { status: 400 });
+    return NextResponse.json(
+      { error: { code: 'MISSING_URL', message: 'Missing url' } },
+      { status: 400 }
+    );
   }
   try {
     const result = await scrape(target);
-    const title = result.meta.og.title ?? result.meta.twitter.title ?? result.meta.basic.title ?? '';
+    const title =
+      result.meta.og.title ??
+      result.meta.twitter.title ??
+      result.meta.basic.title ??
+      '';
     const image = pickBestImage(result.meta) || '';
     const favicon = result.meta.basic.favicon ?? '';
     const warnings = result.diagnostics.warnings ?? [];
     return NextResponse.json({ title, image, favicon, warnings });
   } catch (err: any) {
-    return NextResponse.json({ error: err?.message || 'Failed to scrape' }, { status: 500 });
+    const code: string | undefined =
+      err?.error?.code ||
+      err?.cause?.code ||
+      err?.code ||
+      (typeof err?.message === 'string' && err.message.startsWith('HTTP_')
+        ? err.message
+        : undefined);
+
+    if (code) {
+      if (code.startsWith('HTTP_')) {
+        const status = Number(code.slice(5)) || 500;
+        return NextResponse.json(
+          { error: { code, message: `Upstream responded with ${status}` } },
+          { status }
+        );
+      }
+      const mapped = ERROR_MAP[code];
+      if (mapped) {
+        return NextResponse.json(
+          { error: { code, message: mapped.message } },
+          { status: mapped.status }
+        );
+      }
+    }
+
+    if (err?.name === 'AbortError') {
+      return NextResponse.json(
+        { error: { code: 'TIMEOUT', message: 'Upstream request timed out' } },
+        { status: 504 }
+      );
+    }
+
+    return NextResponse.json(
+      { error: { code: 'UNKNOWN', message: 'Internal server error' } },
+      { status: 500 }
+    );
   }
 }


### PR DESCRIPTION
## Summary
- map `@odeconto/scraper` error codes to HTTP statuses
- ensure API responds with structured error shapes
- add tests for known codes and unknown exceptions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aac1c7f554832b83b622ef67833bd4