### PR TITLE
Validate scrape API URL input

### DIFF
--- a/app/api/scrape/route.ts
+++ b/app/api/scrape/route.ts
@@ -7,6 +7,15 @@ export async function GET(req: Request) {
   if (!target) {
     return NextResponse.json({ error: 'Missing url' }, { status: 400 });
   }
+  let parsed: URL;
+  try {
+    parsed = new URL(target);
+  } catch {
+    return NextResponse.json({ error: 'Invalid url' }, { status: 400 });
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return NextResponse.json({ error: 'URL must use http or https' }, { status: 400 });
+  }
   try {
     const result = await scrape(target);
     const title = result.meta.og.title ?? result.meta.twitter.title ?? result.meta.basic.title ?? '';


### PR DESCRIPTION
## Summary
- validate `url` query param in scrape API
- ensure only http/https URLs are allowed

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68aac1be4204832ba71d3394e56f1172