### PR TITLE
Populate canvas with scraped metadata

### DIFF
--- a/__tests__/api.scrape.route.test.ts
+++ b/__tests__/api.scrape.route.test.ts
@@ -12,7 +12,7 @@ jest.mock('next/server', () => ({
 jest.mock('@odeconto/scraper', () => ({
   scrape: jest.fn(async () => ({
     meta: {
-      og: { title: 'Example Title' },
+      og: { title: 'Example Title', description: 'Example description' },
       twitter: {},
       basic: { favicon: 'https://example.com/favicon.ico' },
       fallback: {}
@@ -34,6 +34,7 @@ describe('GET /api/scrape', () => {
     const data = await res.json();
     expect(data).toEqual({
       title: 'Example Title',
+      description: 'Example description',
       image: 'https://example.com/image.png',
       favicon: 'https://example.com/favicon.ico',
       warnings: ['warn']

--- a/__tests__/metadata-panel.test.tsx
+++ b/__tests__/metadata-panel.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import MetadataPanel from '../components/MetadataPanel';
 import { useMetadataStore } from '../lib/metadataStore';
+import { useEditorStore } from '../lib/editorStore';
 
 describe('MetadataPanel', () => {
   beforeEach(() => {
@@ -12,6 +13,12 @@ describe('MetadataPanel', () => {
       sourceMap: {},
       warnings: []
     });
+    useEditorStore.setState({
+      title: '',
+      subtitle: '',
+      bannerUrl: undefined,
+      logoUrl: undefined
+    });
   });
 
   afterEach(() => {
@@ -22,6 +29,7 @@ describe('MetadataPanel', () => {
     global.fetch = jest.fn(async () => ({
       json: async () => ({
         title: 'Example Title',
+        description: 'Example description',
         image: 'https://example.com/image.png',
         favicon: 'https://example.com/favicon.ico',
         warnings: ['a warning']
@@ -36,8 +44,15 @@ describe('MetadataPanel', () => {
     await waitFor(() => {
       expect(screen.getByDisplayValue('Example Title')).toBeInTheDocument();
     });
+    expect(screen.getByDisplayValue('Example description')).toBeInTheDocument();
     expect(screen.getByDisplayValue('https://example.com/image.png')).toBeInTheDocument();
     expect(screen.getByDisplayValue('https://example.com/favicon.ico')).toBeInTheDocument();
     expect(await screen.findByText('a warning')).toBeInTheDocument();
+
+    const state = useEditorStore.getState();
+    expect(state.title).toBe('Example Title');
+    expect(state.subtitle).toBe('Example description');
+    expect(state.bannerUrl).toBe('https://example.com/image.png');
+    expect(state.logoUrl).toBe('https://example.com/favicon.ico');
   });
 });

--- a/app/api/scrape/route.ts
+++ b/app/api/scrape/route.ts
@@ -18,11 +18,20 @@ export async function GET(req: Request) {
   }
   try {
     const result = await scrape(target);
-    const title = result.meta.og.title ?? result.meta.twitter.title ?? result.meta.basic.title ?? '';
+    const title =
+      result.meta.og.title ??
+      result.meta.twitter.title ??
+      result.meta.basic.title ??
+      '';
+    const description =
+      result.meta.og.description ??
+      result.meta.twitter.description ??
+      result.meta.basic.description ??
+      '';
     const image = pickBestImage(result.meta) || '';
     const favicon = result.meta.basic.favicon ?? '';
     const warnings = result.diagnostics.warnings ?? [];
-    return NextResponse.json({ title, image, favicon, warnings });
+    return NextResponse.json({ title, description, image, favicon, warnings });
   } catch (err: any) {
     return NextResponse.json({ error: err?.message || 'Failed to scrape' }, { status: 500 });
   }

--- a/components/MetadataPanel.tsx
+++ b/components/MetadataPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useMetadataStore } from 'lib/metadataStore';
+import { useEditorStore } from 'lib/editorStore';
 
 /**
  * Panel for editing metadata related to the current Open Graph image. By
@@ -22,6 +23,7 @@ export default function MetadataPanel() {
     setSiteName,
     setWarnings
   } = useMetadataStore();
+  const { setTitle, setSubtitle, setBannerUrl, setLogoUrl } = useEditorStore();
 
   async function handleFetch() {
     if (!url) return;
@@ -29,9 +31,15 @@ export default function MetadataPanel() {
       const res = await fetch(`/api/scrape?url=${encodeURIComponent(url)}`);
       const data = await res.json();
       setSiteName(data.title || '');
+      setDescription(data.description || '');
       setImage(data.image || '');
       setFavicon(data.favicon || '');
       setWarnings(data.warnings || []);
+      // Populate canvas editor with scraped metadata
+      setTitle(data.title || '');
+      setSubtitle(data.description || '');
+      setBannerUrl(data.image || undefined);
+      setLogoUrl(data.favicon || undefined);
     } catch (err: any) {
       setWarnings([err?.message || 'Failed to fetch metadata']);
     }


### PR DESCRIPTION
## Summary
- include page description in `/api/scrape` responses
- apply scraped title, description, image and favicon to canvas via `MetadataPanel`
- extend tests for scraping and metadata panel

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac02d41494832bb554d4b3e04f08c0