### PR TITLE
Add theme tokens for Tailwind utilities

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,14 +2,34 @@
 @tailwind components;
 @tailwind utilities;
 
-html,
-body,
-#root {
-  min-height: 100%;
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 240 10% 3.9%;
+    --primary: 240 5.9% 10%;
+    --primary-foreground: 0 0% 98%;
+    --muted: 240 4.8% 95.9%;
+    --muted-foreground: 240 3.8% 46.1%;
+    --card: 0 0% 100%;
+    --card-foreground: 240 10% 3.9%;
+    --border: 240 5.9% 90%;
+    --input: 240 5.9% 90%;
+    --ring: 240 5.9% 10%;
+    --radius: 0.5rem;
+  }
+
+  html,
+  body,
+  #root {
+    min-height: 100%;
+  }
+
+  body {
+    @apply bg-background text-foreground font-sans;
+  }
 }
 
-body {
-  font-family: theme('fontFamily.sans');
+@layer components {
+  .btn { @apply px-3 py-1.5 rounded-lg border bg-muted hover:bg-muted/80 text-sm; }
+  .btn-primary { @apply bg-primary text-primary-foreground hover:bg-primary/90; }
 }
-.btn { @apply px-3 py-1.5 rounded-lg border bg-muted hover:bg-muted/80 text-sm; }
-.btn-primary { @apply bg-primary text-primary-foreground hover:bg-primary/90; }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,13 +2,55 @@ import type { Config } from 'tailwindcss';
 import forms from '@tailwindcss/forms';
 
 const config: Config = {
+  darkMode: ['class'],
   content: [
     './app/**/*.{ts,tsx}',
     './components/**/*.{ts,tsx}',
     './lib/**/*.{ts,tsx}'
   ],
   theme: {
-    extend: {}
+    extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))'
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))'
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))'
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))'
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))'
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))'
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))'
+        }
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)'
+      }
+    }
   },
   plugins: [forms]
 };


### PR DESCRIPTION
## Summary
- define color and radius tokens in Tailwind config using CSS variables
- set up root theme variables and button component helpers in global CSS

## Testing
- `pnpm test`
- `pnpm lint` (fails: Cannot find package '@eslint/eslintrc')
- `pnpm build` (fails: Cannot find package '@eslint/eslintrc'; Type error in lib/removeBg.ts)


------
https://chatgpt.com/codex/tasks/task_e_68ac2169c3fc832bb925f26d89cbb6c1