### PR TITLE
feat: add toolbar shortcuts and a11y

### DIFF
--- a/__tests__/toolbar-shortcuts.test.tsx
+++ b/__tests__/toolbar-shortcuts.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import Toolbar from '../components/editor/Toolbar';
+
+describe('Toolbar shortcuts', () => {
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('handles undo via click and shortcut', () => {
+    render(<Toolbar />);
+    fireEvent.click(screen.getByRole('button', { name: 'Undo' }));
+    expect(logSpy).toHaveBeenLastCalledWith('undo');
+    fireEvent.keyDown(window, { key: 'z', ctrlKey: true });
+    expect(logSpy).toHaveBeenLastCalledWith('undo');
+  });
+
+  it('handles redo via click and shortcut', () => {
+    render(<Toolbar />);
+    fireEvent.click(screen.getByRole('button', { name: 'Redo' }));
+    expect(logSpy).toHaveBeenLastCalledWith('redo');
+    fireEvent.keyDown(window, { key: 'Z', ctrlKey: true, shiftKey: true });
+    expect(logSpy).toHaveBeenLastCalledWith('redo');
+  });
+
+  it('handles copy meta via click and shortcut', () => {
+    render(<Toolbar />);
+    fireEvent.click(screen.getByRole('button', { name: 'Copy Meta' }));
+    expect(logSpy).toHaveBeenLastCalledWith('copy meta');
+    fireEvent.keyDown(window, { key: 'c', ctrlKey: true });
+    expect(logSpy).toHaveBeenLastCalledWith('copy meta');
+  });
+
+  it('handles save via click and shortcut', () => {
+    render(<Toolbar />);
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(logSpy).toHaveBeenLastCalledWith('save');
+    fireEvent.keyDown(window, { key: 's', ctrlKey: true });
+    expect(logSpy).toHaveBeenLastCalledWith('save');
+  });
+});

--- a/components/editor/Toolbar.tsx
+++ b/components/editor/Toolbar.tsx
@@ -1,16 +1,85 @@
 "use client";
 
+import { useEffect } from "react";
+
 export default function Toolbar() {
+  const handleUndo = () => console.log("undo");
+  const handleRedo = () => console.log("redo");
+  const handleCopyMeta = () => console.log("copy meta");
+  const handleExport = () => console.log("export");
+  const handleSave = () => console.log("save");
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      const isMod = e.metaKey || e.ctrlKey;
+      if (!isMod) return;
+
+      const key = e.key.toLowerCase();
+
+      if (key === "z") {
+        e.preventDefault();
+        if (e.shiftKey) {
+          handleRedo();
+        } else {
+          handleUndo();
+        }
+      } else if (key === "c") {
+        e.preventDefault();
+        handleCopyMeta();
+      } else if (key === "s") {
+        e.preventDefault();
+        handleSave();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [handleUndo, handleRedo, handleCopyMeta, handleSave]);
+
   return (
     <header className="flex items-center justify-between border-b bg-background/80 p-2 backdrop-blur">
       <div className="flex gap-2">
-        <button className="btn" aria-label="Undo">Undo</button>
-        <button className="btn" aria-label="Redo">Redo</button>
+        <button
+          className="btn"
+          aria-label="Undo"
+          title="Undo (Cmd/Ctrl+Z)"
+          onClick={handleUndo}
+        >
+          Undo
+        </button>
+        <button
+          className="btn"
+          aria-label="Redo"
+          title="Redo (Cmd/Ctrl+Shift+Z)"
+          onClick={handleRedo}
+        >
+          Redo
+        </button>
       </div>
       <div className="flex gap-2">
-        <button className="btn" aria-label="Copy Meta">Copy Meta</button>
-        <button className="btn" aria-label="Export">Export</button>
-        <button className="btn" aria-label="Save">Save</button>
+        <button
+          className="btn"
+          aria-label="Copy Meta"
+          title="Copy Meta (Cmd/Ctrl+C)"
+          onClick={handleCopyMeta}
+        >
+          Copy Meta
+        </button>
+        <button
+          className="btn"
+          aria-label="Export"
+          title="Export"
+          onClick={handleExport}
+        >
+          Export
+        </button>
+        <button
+          className="btn"
+          aria-label="Save"
+          title="Save (Cmd/Ctrl+S)"
+          onClick={handleSave}
+        >
+          Save
+        </button>
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- add keyboard shortcut handlers for undo, redo, copy meta, and save
- expose undo/redo/copy/save as aria-labeled buttons with tooltips
- test that shortcuts invoke the same handlers as button clicks

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68ac25539bbc832bbdaceb1ad17caf06