### PR TITLE
feat: center logo by default

### DIFF
--- a/__tests__/canvas-stage.test.tsx
+++ b/__tests__/canvas-stage.test.tsx
@@ -20,4 +20,12 @@ describe('CanvasStage', () => {
     expect(banner.tagName).toBe('IMG');
     expect(banner.getAttribute('src')).toBe('https://example.com/banner.png');
   });
+
+  it('positions the logo at the center by default', () => {
+    useEditorStore.setState({ logoUrl: 'https://example.com/logo.png' });
+    render(<CanvasStage />);
+    const logo = screen.getByAltText('Logo');
+    const container = logo.parentElement as HTMLElement;
+    expect(container).toHaveStyle({ top: '50%', left: '50%' });
+  });
 });

--- a/lib/editorStore.ts
+++ b/lib/editorStore.ts
@@ -46,7 +46,7 @@ export const useEditorStore = create<EditorState>((set) => ({
   theme: 'light',
   layout: 'left',
   accentColor: '#3b82f6',
-  logoPosition: { x: 0, y: 0 },
+  logoPosition: { x: 50, y: 50 },
   logoScale: 1,
   invertLogo: false,
   removeLogoBg: false,


### PR DESCRIPTION
## Summary
- center new logos by default in editor store
- cover default centered logo with a new CanvasStage test

## Testing
- `pnpm lint` (fails: Cannot find package '@eslint/eslintrc')
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac253f5ca0832b862bb4d937e5ddd9