### PR TITLE
feat(editor): add canvas theme and layout controls

### DIFF
--- a/components/editor/CanvasStage.tsx
+++ b/components/editor/CanvasStage.tsx
@@ -1,11 +1,13 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
+import { useEditorStore } from "../../state/editorStore";
 
 export default function CanvasStage() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [zoom, setZoom] = useState(1);
   const base = { w: 1200, h: 630 };
+  const { theme, layout, accentColor } = useEditorStore();
 
   useEffect(() => {
     const el = containerRef.current;
@@ -26,19 +28,22 @@ export default function CanvasStage() {
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
     ctx.clearRect(0, 0, canvas.width, canvas.height);
-    ctx.fillStyle = "#0b0c0f";
+    ctx.fillStyle = theme === "dark" ? "#0b0c0f" : "#ffffff";
     ctx.fillRect(0, 0, canvas.width, canvas.height);
-    ctx.fillStyle = "white";
+    ctx.fillStyle = theme === "dark" ? "#ffffff" : "#000000";
     ctx.font = "bold 48px system-ui, -apple-system, Segoe UI, Roboto";
-    ctx.fillText("OGGenerator — Title", 64, 180);
+    const titleX = layout === "center" ? canvas.width / 2 : 64;
+    const subtitleX = titleX;
+    ctx.textAlign = layout === "center" ? "center" : "left";
+    ctx.fillText("OGGenerator — Title", titleX, 180);
     ctx.font = "24px system-ui, -apple-system, Segoe UI, Roboto";
-    ctx.fillStyle = "#D1D5DB";
-    ctx.fillText("Subtitle goes here", 64, 240);
+    ctx.fillStyle = accentColor;
+    ctx.fillText("Subtitle goes here", subtitleX, 240);
   };
 
   useEffect(() => {
     draw();
-  }, [zoom]);
+  }, [zoom, theme, layout, accentColor]);
 
   return (
     <div ref={containerRef} className="flex h-full w-full items-center justify-center overflow-hidden">

--- a/components/editor/panels/CanvasPanel.tsx
+++ b/components/editor/panels/CanvasPanel.tsx
@@ -1,8 +1,71 @@
 "use client";
+import { useEditorStore } from "../../../state/editorStore";
+
 export default function CanvasPanel() {
+  const {
+    theme,
+    setTheme,
+    layout,
+    setLayout,
+    accentColor,
+    setAccentColor,
+  } = useEditorStore();
+
   return (
     <section className="space-y-3">
-      <p className="text-sm text-gray-500">Canvas settings will appear here.</p>
+      <div>
+        <span className="text-sm" id="theme-label">
+          Theme
+        </span>
+        <div className="mt-1 flex gap-4" role="radiogroup" aria-labelledby="theme-label">
+          <label className="flex items-center gap-1 text-sm">
+            <input
+              type="radio"
+              name="theme"
+              value="light"
+              checked={theme === "light"}
+              onChange={() => setTheme("light")}
+              className="h-4 w-4"
+            />
+            Light
+          </label>
+          <label className="flex items-center gap-1 text-sm">
+            <input
+              type="radio"
+              name="theme"
+              value="dark"
+              checked={theme === "dark"}
+              onChange={() => setTheme("dark")}
+              className="h-4 w-4"
+            />
+            Dark
+          </label>
+        </div>
+      </div>
+
+      <label className="block">
+        <span className="text-sm">Layout</span>
+        <select
+          className="mt-1 w-full rounded-lg border bg-background px-3 py-2"
+          value={layout}
+          onChange={(e) => setLayout(e.target.value as "left" | "center")}
+          aria-label="Layout"
+        >
+          <option value="left">Left</option>
+          <option value="center">Center</option>
+        </select>
+      </label>
+
+      <label className="block">
+        <span className="text-sm">Accent Color</span>
+        <input
+          type="color"
+          className="mt-1 h-8 w-full rounded-lg border bg-background p-1"
+          value={accentColor}
+          onChange={(e) => setAccentColor(e.target.value)}
+          aria-label="Accent Color"
+        />
+      </label>
     </section>
   );
 }

--- a/state/editorStore.ts
+++ b/state/editorStore.ts
@@ -3,13 +3,25 @@ import { create } from "zustand";
 interface EditorState {
   title: string;
   subtitle: string;
+  theme: "light" | "dark";
+  layout: "left" | "center";
+  accentColor: string;
   setTitle: (title: string) => void;
   setSubtitle: (subtitle: string) => void;
+  setTheme: (theme: "light" | "dark") => void;
+  setLayout: (layout: "left" | "center") => void;
+  setAccentColor: (accentColor: string) => void;
 }
 
 export const useEditorStore = create<EditorState>((set) => ({
   title: "",
   subtitle: "",
+  theme: "dark",
+  layout: "left",
+  accentColor: "#D1D5DB",
   setTitle: (title) => set({ title }),
-  setSubtitle: (subtitle) => set({ subtitle })
+  setSubtitle: (subtitle) => set({ subtitle }),
+  setTheme: (theme) => set({ theme }),
+  setLayout: (layout) => set({ layout }),
+  setAccentColor: (accentColor) => set({ accentColor })
 }));


### PR DESCRIPTION
## Summary
- add theme, layout, and accent color state
- expose CanvasPanel controls for theme, layout, and color
- update CanvasStage to render based on editor store

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac250a66b0832bbc96dff093a1872b