### PR TITLE
feat: wire logo panel controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Aplicação Next.js para criar imagens Open Graph personalizadas. Utiliza React,
 - NextAuth para autenticação
 - Jest e Testing Library para testes
 
+## Recursos
+
+- Editor de logo com upload por arquivo, colagem ou URL
+- Remoção de fundo, inversão B/W e máscara circular do logo
+- Controles de escala e centralização do logo
+
 ## Instalação e Uso
 
 Requisitos: Node.js 18+ e pnpm.
@@ -55,7 +61,7 @@ Preencha cada chave com valores obtidos nos provedores OAuth (Google, GitHub, et
 - Presets automáticos de layout e cores ("Surpreenda‑me")
 - Persistência das configurações no `localStorage`
 - Página de login personalizada
-- Melhorias no editor de logo (remoção de fundo e inversão de cores)
+- Arrastar e soltar de logo e outras melhorias
 
 ## Licença
 

--- a/__tests__/logo-panel.test.tsx
+++ b/__tests__/logo-panel.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import LogoPanel from '../components/editor/panels/LogoPanel';
+import { useEditorStore } from '../lib/editorStore';
+
+describe('LogoPanel', () => {
+  beforeEach(() => {
+    useEditorStore.setState({
+      logoFile: undefined,
+      logoUrl: undefined,
+      removeLogoBg: false,
+      invertLogo: false,
+      maskLogo: false,
+      logoScale: 1,
+      logoPosition: { x: 10, y: 20 },
+    });
+  });
+
+  it('handles file, paste and url inputs', async () => {
+    render(<LogoPanel />);
+
+    const file = new File(['img'], 'logo.png', { type: 'image/png' });
+    const fileInput = screen.getByLabelText(/logo file/i);
+    fireEvent.change(fileInput, { target: { files: [file] } });
+    expect(useEditorStore.getState().logoFile).toBe(file);
+
+    (navigator as any).clipboard = {
+      readText: jest.fn().mockResolvedValue('https://example.com/pasted.png'),
+    };
+    await act(async () => {
+      fireEvent.click(screen.getByText(/paste/i));
+    });
+    expect(useEditorStore.getState().logoUrl).toBe('https://example.com/pasted.png');
+
+    jest.spyOn(window, 'prompt').mockReturnValue('https://example.com/url.png');
+    fireEvent.click(screen.getByText(/from url/i));
+    expect(useEditorStore.getState().logoUrl).toBe('https://example.com/url.png');
+    (window.prompt as jest.Mock).mockRestore();
+  });
+
+  it('toggles image processing flags', () => {
+    render(<LogoPanel />);
+    fireEvent.click(screen.getByText(/remove bg/i));
+    expect(useEditorStore.getState().removeLogoBg).toBe(true);
+    fireEvent.click(screen.getByText(/invert b\/w/i));
+    expect(useEditorStore.getState().invertLogo).toBe(true);
+    fireEvent.click(screen.getByText(/mask: circle/i));
+    expect(useEditorStore.getState().maskLogo).toBe(true);
+  });
+
+  it('adjusts scale and position', async () => {
+    render(<LogoPanel />);
+    fireEvent.change(screen.getByLabelText(/scale/i), { target: { value: '2' } });
+    expect(useEditorStore.getState().logoScale).toBeCloseTo(2);
+
+    await act(async () => {
+      useEditorStore.setState({ logoPosition: { x: 30, y: 40 } });
+    });
+    fireEvent.click(screen.getByText(/center/i));
+    expect(useEditorStore.getState().logoPosition).toEqual({ x: 50, y: 50 });
+
+    await act(async () => {
+      useEditorStore.setState({ logoScale: 2, logoPosition: { x: 60, y: 70 } });
+    });
+    fireEvent.click(screen.getByText(/reset/i));
+    expect(useEditorStore.getState().logoScale).toBe(1);
+    expect(useEditorStore.getState().logoPosition).toEqual({ x: 50, y: 50 });
+  });
+});
+

--- a/components/editor/CanvasStage.tsx
+++ b/components/editor/CanvasStage.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
-import { useEditorStore } from "../../state/editorStore";
+import { useEditorStore } from "lib/editorStore";
 
 export default function CanvasStage() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);

--- a/components/editor/panels/CanvasPanel.tsx
+++ b/components/editor/panels/CanvasPanel.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEditorStore } from "../../../state/editorStore";
+import { useEditorStore } from "lib/editorStore";
 
 export default function CanvasPanel() {
   const {

--- a/components/editor/panels/LogoPanel.tsx
+++ b/components/editor/panels/LogoPanel.tsx
@@ -1,24 +1,115 @@
 "use client";
+import { useEditorStore } from "lib/editorStore";
+import type { ChangeEvent } from "react";
+
 export default function LogoPanel() {
+  const {
+    setLogoFile,
+    setLogoUrl,
+    toggleRemoveLogoBg,
+    toggleInvertLogo,
+    toggleMaskLogo,
+    logoScale,
+    setLogoScale,
+    setLogoPosition,
+  } = useEditorStore();
+
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) setLogoFile(file);
+  };
+
+  const handlePaste = async () => {
+    try {
+      if (navigator.clipboard && "read" in navigator.clipboard) {
+        // @ts-ignore ClipboardItem type
+        const items = await navigator.clipboard.read();
+        for (const item of items) {
+          // @ts-ignore ClipboardItem types
+          const type = item.types.find((t: string) => t.startsWith("image/"));
+          if (type) {
+            // @ts-ignore ClipboardItem getType
+            const blob = await item.getType(type);
+            const file = new File([blob], "pasted-image" + type.replace("image/", "."), { type });
+            setLogoFile(file);
+            return;
+          }
+        }
+      }
+      if (navigator.clipboard && navigator.clipboard.readText) {
+        const text = await navigator.clipboard.readText();
+        if (text.startsWith("http")) {
+          setLogoUrl(text);
+        }
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleUrl = () => {
+    const url = prompt("Image URL");
+    if (url) setLogoUrl(url);
+  };
+
+  const handleReset = () => {
+    setLogoScale(1);
+    setLogoPosition(50, 50);
+  };
+
+  const handleCenter = () => {
+    setLogoPosition(50, 50);
+  };
+
   return (
     <section className="space-y-3">
       <div className="flex items-center gap-2">
-        <input type="file" accept="image/png,image/svg+xml" />
-        <button className="btn">Paste</button>
-        <button className="btn">From URL</button>
+        <input
+          type="file"
+          accept="image/png,image/svg+xml"
+          onChange={handleFileChange}
+          aria-label="Logo file"
+        />
+        <button className="btn" onClick={handlePaste}>
+          Paste
+        </button>
+        <button className="btn" onClick={handleUrl}>
+          From URL
+        </button>
       </div>
       <div className="grid grid-cols-3 gap-2">
-        <button className="btn">Remove BG</button>
-        <button className="btn">Invert B/W</button>
-        <button className="btn">Mask: Circle</button>
+        <button className="btn" onClick={toggleRemoveLogoBg}>
+          Remove BG
+        </button>
+        <button className="btn" onClick={toggleInvertLogo}>
+          Invert B/W
+        </button>
+        <button className="btn" onClick={toggleMaskLogo}>
+          Mask: Circle
+        </button>
       </div>
       <div>
-        <label className="text-sm">Scale</label>
-        <input type="range" min={0.2} max={3} step={0.01} className="w-full" />
+        <label className="text-sm" htmlFor="logo-scale">
+          Scale
+        </label>
+        <input
+          id="logo-scale"
+          type="range"
+          min={0.2}
+          max={3}
+          step={0.01}
+          className="w-full"
+          value={logoScale}
+          onChange={(e) => setLogoScale(parseFloat(e.target.value))}
+        />
       </div>
       <div className="grid grid-cols-2 gap-2">
-        <button className="btn">Reset</button>
-        <button className="btn">Center</button>
+        <button className="btn" onClick={handleReset}>
+          Reset
+        </button>
+        <button className="btn" onClick={handleCenter}>
+          Center
+        </button>
       </div>
     </section>
   );

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -11,7 +11,7 @@ OGGenerator is a one‑page (expandable) app to **compose Open Graph images** wi
 **MVP Goals**
 
 * Authenticated session (Google, GitHub, LinkedIn, Twitter/X, Facebook; *Instagram: see note below*).
-* Editor with: title, subtitle, theme (light/dark), layout (left/center), background (color/gradient/image), size presets, and **logo editing** (translate, scale, remove BG, invert B/W).
+* Editor with: title, subtitle, theme (light/dark), layout (left/center), background (color/gradient/image), size presets, and **logo editing** (upload via file/paste/URL, translate, scale, remove BG, invert B/W, mask).
 * Export PNG (1200×630 default; extras 1600×900, 1920×1005) and copy meta tags.
 * Basic persistence (local + per‑user cloud).
 
@@ -319,10 +319,10 @@ pnpm dev
 
 ### Sprint 3 — Logo Tools (2–3 days)
 
-* [ ] Upload: drag‑and‑drop + paste + URL.
-* [ ] Translate + scale + mask (circle) interaction.
-* [ ] **Remove Background** via WASM in WebWorker (lazy‑loaded).
-* [ ] **Invert B/W** filter + toggle.
+* [ ] Upload: drag‑and‑drop + paste + URL (file input, paste and URL wired; drag‑and‑drop pending).
+* [ ] Translate + scale + mask (circle) interaction (scale slider and mask toggle added; drag translate pending).
+* [x] **Remove Background** via WASM in WebWorker (toggle integrated with helper).
+* [x] **Invert B/W** filter + toggle.
 
 ### Sprint 4 — Export & Meta (1–2 days)
 

--- a/docs/log/2025-08-25.md
+++ b/docs/log/2025-08-25.md
@@ -1,0 +1,8 @@
+# 2025-08-25
+
+## Summary
+- Wired logo tools to editor store: file/paste/url inputs, background removal, inversion, masking, scaling and positioning.
+
+## Changed
+- Added bindings for logo inputs and image processing toggles.
+- Connected scale slider and reset/center actions to logo state.


### PR DESCRIPTION
## Summary
- connect logo file, paste, and URL inputs to the editor store
- add toggles for background removal, color inversion, and masking
- expose logo scaling and positioning controls

## Screenshots/GIF

## Docs Updated
- [x] docs/log/2025-08-25.md
- [x] docs/dev_doc.md
- [x] README.md

## Tests
- [x] Unit
- [ ] Component
- [ ] E2E

## Checklist
- [ ] A11y considered
- [ ] Fallbacks & errors handled
- [ ] Env vars documented (if any)


------
https://chatgpt.com/codex/tasks/task_e_68ac3665bd44832baadf955f37d15733