### PR TITLE
feat: wire export panel actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pnpm dev
   - `AuthButtons.tsx`: botões de login/logout
   - `CanvasStage.tsx`: preview da imagem OG
   - `EditorControls.tsx`: formulário para editar conteúdo
-  - `ExportControls.tsx`: exportação de PNG e metatags (export em desenvolvimento)
+  - `ExportControls.tsx`: exportação de PNG e metatags
 - `lib/`:
   - `authOptions.ts`: configuração do NextAuth
   - `editorStore.ts`: estado global com Zustand

--- a/__tests__/export-panel.test.tsx
+++ b/__tests__/export-panel.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import ExportPanel from '../components/editor/panels/ExportPanel';
+import { useEditorStore } from '../lib/editorStore';
+import { exportElementAsPng } from '../lib/images';
+import { copyMetaTags } from '../lib/meta';
+
+jest.mock('../lib/images', () => ({
+  exportElementAsPng: jest.fn(),
+}));
+
+jest.mock('../lib/meta', () => ({
+  copyMetaTags: jest.fn(),
+}));
+
+describe('ExportPanel', () => {
+  beforeEach(() => {
+    useEditorStore.setState({ title: 'T', subtitle: 'S' });
+    document.body.innerHTML = '<div id="og-canvas"></div>';
+  });
+
+  it('exports canvas as PNG', () => {
+    const mock = exportElementAsPng as jest.Mock;
+    render(<ExportPanel />);
+    fireEvent.click(screen.getByRole('button', { name: /export png/i }));
+    expect(mock).toHaveBeenCalledWith(
+      document.getElementById('og-canvas'),
+      { width: 1200, height: 630 },
+      'og-image-1200x630.png'
+    );
+  });
+
+  it('copies meta tags', () => {
+    const mock = copyMetaTags as jest.Mock;
+    render(<ExportPanel />);
+    fireEvent.click(screen.getByRole('button', { name: /copy meta/i }));
+    expect(mock).toHaveBeenCalledWith({ title: 'T', description: 'S' });
+  });
+});

--- a/__tests__/meta.test.ts
+++ b/__tests__/meta.test.ts
@@ -1,0 +1,25 @@
+import { buildMetaTags, copyMetaTags } from '../lib/meta';
+
+describe('meta helpers', () => {
+  it('builds meta tag block', () => {
+    const tags = buildMetaTags({
+      title: 'Title',
+      description: 'Desc',
+      image: 'img.png',
+    });
+    expect(tags).toBe(
+      `<meta property="og:title" content="Title" />\n` +
+        `<meta property="og:description" content="Desc" />\n` +
+        `<meta property="og:type" content="website" />\n` +
+        `<meta property="og:image" content="img.png" />\n` +
+        `<meta name="twitter:card" content="summary_large_image" />`
+    );
+  });
+
+  it('writes tags to clipboard', async () => {
+    const writeText = jest.fn();
+    Object.assign(navigator, { clipboard: { writeText } });
+    await copyMetaTags({ title: 't', description: 'd' });
+    expect(writeText).toHaveBeenCalled();
+  });
+});

--- a/components/editor/CanvasStage.tsx
+++ b/components/editor/CanvasStage.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
-import { useEditorStore } from "../../state/editorStore";
+import { useEditorStore } from "lib/editorStore";
 
 export default function CanvasStage() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);

--- a/components/editor/panels/CanvasPanel.tsx
+++ b/components/editor/panels/CanvasPanel.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEditorStore } from "../../../state/editorStore";
+import { useEditorStore } from "lib/editorStore";
 
 export default function CanvasPanel() {
   const {

--- a/components/editor/panels/ExportPanel.tsx
+++ b/components/editor/panels/ExportPanel.tsx
@@ -1,14 +1,64 @@
 "use client";
+
+import { useState } from "react";
+import { useEditorStore } from "lib/editorStore";
+import { exportElementAsPng, type ImageSize } from "lib/images";
+import { copyMetaTags } from "lib/meta";
+
+const SIZE_PRESETS: Record<string, ImageSize> = {
+  "1200x630": { width: 1200, height: 630 },
+  "1600x900": { width: 1600, height: 900 },
+  "1920x1005": { width: 1920, height: 1005 },
+};
+
 export default function ExportPanel() {
+  const [selected, setSelected] = useState<keyof typeof SIZE_PRESETS>("1200x630");
+  const { title, subtitle } = useEditorStore();
+
+  const handleExport = async () => {
+    const el = document.getElementById("og-canvas");
+    if (!el) {
+      console.error("Canvas element #og-canvas not found");
+      return;
+    }
+    try {
+      await exportElementAsPng(
+        el as HTMLElement,
+        SIZE_PRESETS[selected],
+        `og-image-${selected}.png`
+      );
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleCopyMeta = async () => {
+    try {
+      await copyMetaTags({ title, description: subtitle });
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   return (
     <section className="space-y-3">
       <div className="grid grid-cols-3 gap-2">
-        <button className="btn">1200×630</button>
-        <button className="btn">1600×900</button>
-        <button className="btn">1920×1005</button>
+        {Object.keys(SIZE_PRESETS).map((key) => (
+          <button
+            key={key}
+            className={`btn${selected === key ? " btn-primary" : ""}`}
+            onClick={() => setSelected(key as keyof typeof SIZE_PRESETS)}
+          >
+            {key.replace("x", "×")}
+          </button>
+        ))}
       </div>
-      <button className="btn btn-primary w-full">Export PNG</button>
-      <button className="btn w-full">Copy Meta</button>
+      <button className="btn btn-primary w-full" onClick={handleExport}>
+        Export PNG
+      </button>
+      <button className="btn w-full" onClick={handleCopyMeta}>
+        Copy Meta
+      </button>
     </section>
   );
 }

--- a/docs/log/2025-08-25.md
+++ b/docs/log/2025-08-25.md
@@ -1,0 +1,11 @@
+# 2025-08-25
+
+## Summary
+- Wire export panel actions to PNG export utility and meta tag clipboard helper.
+
+## Changed
+- components/editor/panels/ExportPanel.tsx
+- lib/meta.ts
+- components/editor/CanvasStage.tsx
+- components/editor/panels/CanvasPanel.tsx
+- README.md

--- a/lib/meta.ts
+++ b/lib/meta.ts
@@ -1,0 +1,21 @@
+export interface MetaOptions {
+  title: string;
+  description: string;
+  image?: string;
+}
+
+export function buildMetaTags({ title, description, image }: MetaOptions): string {
+  const tags = [
+    `<meta property="og:title" content="${title}" />`,
+    `<meta property="og:description" content="${description}" />`,
+    `<meta property="og:type" content="website" />`,
+    image ? `<meta property="og:image" content="${image}" />` : null,
+    `<meta name="twitter:card" content="summary_large_image" />`
+  ];
+  return tags.filter(Boolean).join('\n');
+}
+
+export async function copyMetaTags(options: MetaOptions): Promise<void> {
+  const tags = buildMetaTags(options);
+  await navigator.clipboard.writeText(tags);
+}


### PR DESCRIPTION
## Summary
- hook Export Panel into PNG exporter and meta clipboard helper
- add reusable meta tag builder and clipboard utility
- update docs and tests for export and meta features

## Docs Updated
- [x] docs/log/2025-08-25.md
- [ ] docs/dev_doc.md
- [ ] README.md

## Tests
- [x] `pnpm lint`
- [x] `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac36673a4c832b805a7e393ad003ae