### PR TITLE
Add Metadata and Presets tabs to inspector

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ pnpm dev
   - `AuthButtons.tsx`: botões de login/logout
   - `CanvasStage.tsx`: preview da imagem OG
   - `EditorControls.tsx`: formulário para editar conteúdo
+  - `editor/Inspector.tsx`: painel lateral com abas (Canvas, Text, Logo, Metadata, Presets, Export)
+  - `MetadataPanel.tsx` e `PresetsPanel.tsx`: painéis reutilizados nas respectivas abas
   - `ExportControls.tsx`: exportação de PNG e metatags (export em desenvolvimento)
 - `lib/`:
   - `authOptions.ts`: configuração do NextAuth

--- a/__tests__/inspector-tabs.test.tsx
+++ b/__tests__/inspector-tabs.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useMetadataStore } from '../lib/metadataStore';
+import { useEditorStore } from '../lib/editorStore';
+
+jest.mock('../lib/randomStyle', () => ({
+  generateRandomPreset: jest.fn(() => ({
+    theme: 'dark',
+    layout: 'center',
+    accentColor: '#000000'
+  }))
+}));
+
+import Inspector from '../components/editor/Inspector';
+
+describe('Inspector tabs', () => {
+  beforeEach(() => {
+    useMetadataStore.setState({
+      description: '',
+      image: '',
+      favicon: '',
+      siteName: '',
+      sourceMap: {},
+      warnings: []
+    });
+    useEditorStore.setState({
+      title: '',
+      subtitle: '',
+      theme: 'light',
+      layout: 'left',
+      accentColor: '#3b82f6',
+      bannerUrl: undefined,
+      logoFile: undefined,
+      logoUrl: undefined,
+      logoPosition: { x: 0, y: 0 },
+      logoScale: 1,
+      invertLogo: false,
+      removeLogoBg: false,
+      maskLogo: false,
+      presets: []
+    });
+  });
+
+  it('updates metadata store via Metadata tab', () => {
+    render(<Inspector />);
+    fireEvent.click(screen.getByRole('button', { name: /metadata/i }));
+    fireEvent.change(screen.getByLabelText(/nome do site/i), {
+      target: { value: 'My Site' }
+    });
+    expect(useMetadataStore.getState().siteName).toBe('My Site');
+  });
+
+  it('generates and applies preset via Presets tab', () => {
+    render(<Inspector />);
+    fireEvent.click(screen.getByRole('button', { name: /presets/i }));
+    fireEvent.click(
+      screen.getByRole('button', { name: /gerar preset aleatório/i })
+    );
+    const state = useEditorStore.getState();
+    expect(state.presets).toHaveLength(1);
+    expect(state.theme).toBe('dark');
+    expect(state.layout).toBe('center');
+    expect(state.accentColor).toBe('#000000');
+  });
+});

--- a/components/editor/CanvasStage.tsx
+++ b/components/editor/CanvasStage.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
-import { useEditorStore } from "../../state/editorStore";
+import { useEditorStore } from "../../lib/editorStore";
 
 export default function CanvasStage() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);

--- a/components/editor/Inspector.tsx
+++ b/components/editor/Inspector.tsx
@@ -4,11 +4,15 @@ import CanvasPanel from "./panels/CanvasPanel";
 import TextPanel from "./panels/TextPanel";
 import LogoPanel from "./panels/LogoPanel";
 import ExportPanel from "./panels/ExportPanel";
+import MetadataPanel from "../MetadataPanel";
+import PresetsPanel from "../PresetsPanel";
 
 const tabs = [
   { id: "canvas", label: "Canvas", component: CanvasPanel },
   { id: "text", label: "Text", component: TextPanel },
   { id: "logo", label: "Logo", component: LogoPanel },
+  { id: "metadata", label: "Metadata", component: MetadataPanel },
+  { id: "presets", label: "Presets", component: PresetsPanel },
   { id: "export", label: "Export", component: ExportPanel }
 ];
 

--- a/components/editor/panels/CanvasPanel.tsx
+++ b/components/editor/panels/CanvasPanel.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEditorStore } from "../../../state/editorStore";
+import { useEditorStore } from "../../../lib/editorStore";
 
 export default function CanvasPanel() {
   const {

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -75,6 +75,10 @@ OGGenerator is a one‑page (expandable) app to **compose Open Graph images** wi
 └─ README.md
 ```
 
+### Inspector Tabs
+
+The editor's right-hand inspector groups controls into individual panels. Tabs are now available for **Canvas**, **Text**, **Logo**, **Metadata**, **Presets**, and **Export**, each rendering its respective `*Panel` component.
+
 ---
 
 ## 4) Authentication (NextAuth.js)

--- a/docs/log/2025-08-25.md
+++ b/docs/log/2025-08-25.md
@@ -1,0 +1,9 @@
+# 2025-08-25
+
+## Summary
+- Added Metadata and Presets tabs to the inspector using existing panels.
+
+## Changed
+- Integrated `MetadataPanel` and `PresetsPanel` into `components/editor/Inspector.tsx`.
+- Added tests validating metadata store updates and preset generation within the inspector.
+- Documented new tabs in README and dev docs.

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,4 +1,4 @@
-import nextJest from 'next/jest';
+import nextJest from 'next/jest.js';
 
 const createJestConfig = nextJest({ dir: './' });
 


### PR DESCRIPTION
## Summary
- add Metadata and Presets tabs reusing existing panels
- test inspector tabs and preset generation
- document new tabs and log changes

## Screenshots/GIF
(none)

## Docs Updated
- [x] docs/log/2025-08-25.md
- [x] docs/dev_doc.md
- [x] README.md

## Tests
- [x] Unit (pnpm test)
- [x] Lint (pnpm lint)

## Checklist
- [ ] A11y considered
- [ ] Fallbacks & errors handled
- [ ] Env vars documented (if any)


------
https://chatgpt.com/codex/tasks/task_e_68ac3669eb8c832ba7304265b5d1cbb3