### PR TITLE
Add editor history and meta utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,21 @@ Preencha cada chave com valores obtidos nos provedores OAuth (Google, GitHub, et
 
 - Exportação direta para PNG com alta resolução
 - Presets automáticos de layout e cores ("Surpreenda‑me")
-- Persistência das configurações no `localStorage`
 - Página de login personalizada
 - Melhorias no editor de logo (remoção de fundo e inversão de cores)
+
+## Testes
+
+```bash
+pnpm test
+```
+
+## Atalhos de Teclado
+
+- **Desfazer:** Ctrl/Cmd + Z
+- **Refazer:** Ctrl/Cmd + Shift + Z
+- **Copiar metatags:** Ctrl/Cmd + C
+- **Salvar preset:** Ctrl/Cmd + S
 
 ## Licença
 

--- a/__tests__/meta.test.ts
+++ b/__tests__/meta.test.ts
@@ -1,0 +1,17 @@
+import { buildMetaTags } from '../lib/meta';
+
+describe('buildMetaTags', () => {
+  it('builds OG and Twitter meta tags', () => {
+    const tags = buildMetaTags({
+      title: 'Hello',
+      description: 'World',
+      image: 'https://example.com/img.png',
+      url: 'https://example.com',
+    });
+    expect(tags).toContain('<meta property="og:title" content="Hello" />');
+    expect(tags).toContain('<meta property="og:description" content="World" />');
+    expect(tags).toContain('<meta property="og:image" content="https://example.com/img.png" />');
+    expect(tags).toContain('<meta property="og:url" content="https://example.com" />');
+    expect(tags).toContain('<meta name="twitter:card" content="summary_large_image" />');
+  });
+});

--- a/__tests__/toolbar-shortcuts.test.tsx
+++ b/__tests__/toolbar-shortcuts.test.tsx
@@ -1,46 +1,80 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import Toolbar from '../components/editor/Toolbar';
+import { useEditorStore } from '../lib/editorStore';
+import { buildMetaTags } from '../lib/meta';
+import { exportElementAsPng } from '../lib/images';
+
+jest.mock('../lib/images', () => ({
+  exportElementAsPng: jest.fn().mockResolvedValue(undefined),
+}));
 
 describe('Toolbar shortcuts', () => {
-  let logSpy: jest.SpyInstance;
-
   beforeEach(() => {
-    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    logSpy.mockRestore();
+    useEditorStore.getState().reset();
+    Object.assign(navigator, {
+      clipboard: { writeText: jest.fn().mockResolvedValue(undefined) },
+    });
   });
 
   it('handles undo via click and shortcut', () => {
+    useEditorStore.getState().setTitle('initial');
+    useEditorStore.getState().setTitle('changed');
     render(<Toolbar />);
     fireEvent.click(screen.getByRole('button', { name: 'Undo' }));
-    expect(logSpy).toHaveBeenLastCalledWith('undo');
+    expect(useEditorStore.getState().title).toBe('initial');
+    useEditorStore.getState().setTitle('changed');
     fireEvent.keyDown(window, { key: 'z', ctrlKey: true });
-    expect(logSpy).toHaveBeenLastCalledWith('undo');
+    expect(useEditorStore.getState().title).toBe('initial');
   });
 
   it('handles redo via click and shortcut', () => {
+    useEditorStore.getState().setTitle('initial');
+    useEditorStore.getState().setTitle('changed');
     render(<Toolbar />);
+    fireEvent.click(screen.getByRole('button', { name: 'Undo' }));
     fireEvent.click(screen.getByRole('button', { name: 'Redo' }));
-    expect(logSpy).toHaveBeenLastCalledWith('redo');
+    expect(useEditorStore.getState().title).toBe('changed');
+    useEditorStore.getState().setTitle('initial');
+    useEditorStore.getState().setTitle('changed');
+    fireEvent.keyDown(window, { key: 'z', ctrlKey: true });
     fireEvent.keyDown(window, { key: 'Z', ctrlKey: true, shiftKey: true });
-    expect(logSpy).toHaveBeenLastCalledWith('redo');
+    expect(useEditorStore.getState().title).toBe('changed');
   });
 
-  it('handles copy meta via click and shortcut', () => {
+  it('handles copy meta via click and shortcut', async () => {
+    useEditorStore.getState().setTitle('My Title');
+    useEditorStore.getState().setSubtitle('My Desc');
     render(<Toolbar />);
+    const expected = buildMetaTags({ title: 'My Title', description: 'My Desc' });
     fireEvent.click(screen.getByRole('button', { name: 'Copy Meta' }));
-    expect(logSpy).toHaveBeenLastCalledWith('copy meta');
+    await waitFor(() =>
+      expect((navigator.clipboard as any).writeText).toHaveBeenLastCalledWith(
+        expected,
+      ),
+    );
     fireEvent.keyDown(window, { key: 'c', ctrlKey: true });
-    expect(logSpy).toHaveBeenLastCalledWith('copy meta');
+    await waitFor(() =>
+      expect((navigator.clipboard as any).writeText).toHaveBeenLastCalledWith(
+        expected,
+      ),
+    );
   });
 
   it('handles save via click and shortcut', () => {
     render(<Toolbar />);
+    expect(useEditorStore.getState().presets).toHaveLength(0);
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
-    expect(logSpy).toHaveBeenLastCalledWith('save');
+    expect(useEditorStore.getState().presets).toHaveLength(1);
     fireEvent.keyDown(window, { key: 's', ctrlKey: true });
-    expect(logSpy).toHaveBeenLastCalledWith('save');
+    expect(useEditorStore.getState().presets).toHaveLength(2);
+  });
+
+  it('exports image via click', async () => {
+    const element = document.createElement('div');
+    element.id = 'og-canvas';
+    document.body.appendChild(element);
+    render(<Toolbar />);
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+    await waitFor(() => expect(exportElementAsPng).toHaveBeenCalled());
   });
 });

--- a/components/ExportControls.tsx
+++ b/components/ExportControls.tsx
@@ -4,6 +4,7 @@ import { useEditorStore } from 'lib/editorStore';
 import { useState } from 'react';
 import { exportElementAsPng, ImageSize } from 'lib/images';
 import { generateRandomStyle, type RandomStyle } from 'lib/randomStyle';
+import { buildMetaTags } from 'lib/meta';
 
 /**
  * Buttons to export the generated Open Graph image and copy the associated
@@ -23,12 +24,7 @@ export default function ExportControls() {
 
 
   const handleCopyMeta = async () => {
-    const tags = [
-      `<meta property="og:title" content="${title}" />`,
-      `<meta property="og:description" content="${subtitle}" />`,
-      `<meta property="og:type" content="website" />`,
-      `<meta name="twitter:card" content="summary_large_image" />`
-    ].join('\n');
+    const tags = buildMetaTags({ title, description: subtitle });
     try {
       await navigator.clipboard.writeText(tags);
       alert('Tags OG copiadas para a área de transferência!');

--- a/components/editor/CanvasStage.tsx
+++ b/components/editor/CanvasStage.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
-import { useEditorStore } from "../../state/editorStore";
+import { useEditorStore } from "lib/editorStore";
 
 export default function CanvasStage() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);

--- a/components/editor/Toolbar.tsx
+++ b/components/editor/Toolbar.tsx
@@ -1,21 +1,50 @@
 "use client";
 
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
+import { useEditorStore } from "lib/editorStore";
+import { exportElementAsPng } from "lib/images";
+import { buildMetaTags } from "lib/meta";
 
 export default function Toolbar() {
-  const handleUndo = () => console.log("undo");
-  const handleRedo = () => console.log("redo");
-  const handleCopyMeta = () => console.log("copy meta");
-  const handleExport = () => console.log("export");
-  const handleSave = () => console.log("save");
+  const {
+    undo,
+    redo,
+    addPreset,
+    theme,
+    layout,
+    accentColor,
+    title,
+    subtitle,
+  } = useEditorStore();
+
+  const handleUndo = useCallback(() => undo(), [undo]);
+  const handleRedo = useCallback(() => redo(), [redo]);
+  const handleCopyMeta = useCallback(async () => {
+    const tags = buildMetaTags({ title, description: subtitle });
+    try {
+      await navigator.clipboard.writeText(tags);
+    } catch (err) {
+      console.error(err);
+    }
+  }, [title, subtitle]);
+  const handleExport = useCallback(async () => {
+    const element = document.getElementById("og-canvas");
+    if (!element) return;
+    try {
+      await exportElementAsPng(element, { width: 1200, height: 630 });
+    } catch (err) {
+      console.error(err);
+    }
+  }, []);
+  const handleSave = useCallback(() => {
+    addPreset({ theme, layout, accentColor });
+  }, [addPreset, theme, layout, accentColor]);
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       const isMod = e.metaKey || e.ctrlKey;
       if (!isMod) return;
-
       const key = e.key.toLowerCase();
-
       if (key === "z") {
         e.preventDefault();
         if (e.shiftKey) {

--- a/components/editor/panels/CanvasPanel.tsx
+++ b/components/editor/panels/CanvasPanel.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEditorStore } from "../../../state/editorStore";
+import { useEditorStore } from "lib/editorStore";
 
 export default function CanvasPanel() {
   const {

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -24,7 +24,7 @@ OGGenerator is a one‑page (expandable) app to **compose Open Graph images** wi
 * **Auth:** NextAuth.js (Auth.js) with OAuth providers (see configuration below).
 * **Storage:**
 
-  * Local state: Zustand or React Context.
+  * Local state: Zustand with undo/redo history and localStorage persistence.
   * Cloud: Vercel KV/Upstash **or** Supabase (auth‑agnostic) **or** Planetscale/Neon (if SQL preferred).
   * Object storage for uploads (logo): Vercel Blob **or** Supabase Storage/S3‑compatible bucket.
 * **Image Processing:** HTMLCanvas + OffscreenCanvas + WebWorker. For **background removal**, use `@imgly/background-removal` (WASM U^2‑Net) or `background-removal` (WASM).

--- a/docs/log/2025-08-25.md
+++ b/docs/log/2025-08-25.md
@@ -1,0 +1,10 @@
+# 2025-08-25
+
+## Summary
+- Added undo/redo history with persisted editor state.
+- Wired toolbar actions for copy meta, export PNG and saving presets.
+- Introduced meta-tag builder utility.
+
+## Changed
+- Connected keyboard shortcuts to new handlers.
+- Updated tests and documentation.

--- a/lib/editorStore.ts
+++ b/lib/editorStore.ts
@@ -1,14 +1,9 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 import type { Preset } from './randomStyle';
 
-
-/**
- * Definition of the editor's state. This store manages the current values of
- * fields used to generate an Open Graph image as well as transforms applied
- * to the uploaded logo. Individual fields are updated via dedicated setter
- * actions to make state changes predictable and easy to trace.
- */
-export interface EditorState {
+// State without actions for history snapshots
+interface EditorData {
   title: string;
   subtitle: string;
   theme: 'light' | 'dark';
@@ -23,7 +18,9 @@ export interface EditorState {
   removeLogoBg: boolean;
   maskLogo: boolean;
   presets: Preset[];
-  // actions
+}
+
+export interface EditorState extends EditorData {
   setTitle: (value: string) => void;
   setSubtitle: (value: string) => void;
   setTheme: (value: 'light' | 'dark') => void;
@@ -39,9 +36,12 @@ export interface EditorState {
   toggleMaskLogo: () => void;
   addPreset: (preset: Preset) => void;
   applyPreset: (preset: Preset) => void;
+  undo: () => void;
+  redo: () => void;
+  reset: () => void;
 }
 
-export const useEditorStore = create<EditorState>((set) => ({
+const initialState: EditorData = {
   title: '',
   subtitle: '',
   theme: 'light',
@@ -53,25 +53,107 @@ export const useEditorStore = create<EditorState>((set) => ({
   removeLogoBg: false,
   maskLogo: false,
   presets: [],
-  setTitle: (value) => set({ title: value }),
-  setSubtitle: (value) => set({ subtitle: value }),
-  setTheme: (value) => set({ theme: value }),
-  setLayout: (value) => set({ layout: value }),
-  setAccentColor: (value) => set({ accentColor: value }),
-  setBannerUrl: (value) => set({ bannerUrl: value }),
-  setLogoFile: (file) => set({ logoFile: file, logoUrl: undefined }),
-  setLogoUrl: (url) => set({ logoUrl: url, logoFile: undefined }),
-  setLogoPosition: (x, y) => set({ logoPosition: { x, y } }),
-  setLogoScale: (scale) => set({ logoScale: scale }),
-  toggleInvertLogo: () => set((state) => ({ invertLogo: !state.invertLogo })),
-  toggleRemoveLogoBg: () => set((state) => ({ removeLogoBg: !state.removeLogoBg })),
-  toggleMaskLogo: () => set((state) => ({ maskLogo: !state.maskLogo })),
-  addPreset: (preset) =>
-    set((state) => ({ presets: [...state.presets, preset] })),
-  applyPreset: (preset) =>
-    set({
-      theme: preset.theme,
-      layout: preset.layout,
-      accentColor: preset.accentColor
-    })
-}));
+};
+
+export const useEditorStore = create<EditorState>()(
+  persist(
+    (set, get) => {
+      const past: EditorData[] = [];
+      const future: EditorData[] = [];
+
+      const stripActions = (state: EditorState): EditorData => {
+        const {
+          setTitle,
+          setSubtitle,
+          setTheme,
+          setLayout,
+          setAccentColor,
+          setBannerUrl,
+          setLogoFile,
+          setLogoUrl,
+          setLogoPosition,
+          setLogoScale,
+          toggleInvertLogo,
+          toggleRemoveLogoBg,
+          toggleMaskLogo,
+          addPreset,
+          applyPreset,
+          undo,
+          redo,
+          reset,
+          ...data
+        } = state;
+        return data;
+      };
+
+      const apply = (partial: Partial<EditorData>) =>
+        set((state) => {
+          past.push(stripActions(state));
+          future.length = 0;
+          return { ...state, ...partial };
+        });
+
+      return {
+        ...initialState,
+        setTitle: (value) => apply({ title: value }),
+        setSubtitle: (value) => apply({ subtitle: value }),
+        setTheme: (value) => apply({ theme: value }),
+        setLayout: (value) => apply({ layout: value }),
+        setAccentColor: (value) => apply({ accentColor: value }),
+        setBannerUrl: (value) => apply({ bannerUrl: value }),
+        setLogoFile: (file) => apply({ logoFile: file, logoUrl: undefined }),
+        setLogoUrl: (url) => apply({ logoUrl: url, logoFile: undefined }),
+        setLogoPosition: (x, y) => apply({ logoPosition: { x, y } }),
+        setLogoScale: (scale) => apply({ logoScale: scale }),
+        toggleInvertLogo: () => apply({ invertLogo: !get().invertLogo }),
+        toggleRemoveLogoBg: () => apply({ removeLogoBg: !get().removeLogoBg }),
+        toggleMaskLogo: () => apply({ maskLogo: !get().maskLogo }),
+        addPreset: (preset) =>
+          set((state) => ({ presets: [...state.presets, preset] })),
+        applyPreset: (preset) =>
+          apply({
+            theme: preset.theme,
+            layout: preset.layout,
+            accentColor: preset.accentColor,
+          }),
+        undo: () =>
+          set((state) => {
+            const previous = past.pop();
+            if (!previous) return state;
+            future.push(stripActions(state));
+            return { ...state, ...previous };
+          }),
+        redo: () =>
+          set((state) => {
+            const next = future.pop();
+            if (!next) return state;
+            past.push(stripActions(state));
+            return { ...state, ...next };
+          }),
+        reset: () => {
+          past.length = 0;
+          future.length = 0;
+          set(initialState);
+        },
+      };
+    },
+    {
+      name: 'editor-store',
+      partialize: (state) => ({
+        title: state.title,
+        subtitle: state.subtitle,
+        theme: state.theme,
+        layout: state.layout,
+        accentColor: state.accentColor,
+        bannerUrl: state.bannerUrl,
+        logoUrl: state.logoUrl,
+        logoPosition: state.logoPosition,
+        logoScale: state.logoScale,
+        invertLogo: state.invertLogo,
+        removeLogoBg: state.removeLogoBg,
+        maskLogo: state.maskLogo,
+        presets: state.presets,
+      }),
+    }
+  )
+);

--- a/lib/meta.ts
+++ b/lib/meta.ts
@@ -1,0 +1,28 @@
+export interface MetaOptions {
+  title: string;
+  description: string;
+  image?: string;
+  url?: string;
+}
+
+/**
+ * Build a block of Open Graph and Twitter meta tags.
+ */
+export function buildMetaTags({ title, description, image, url }: MetaOptions): string {
+  const tags: string[] = [
+    `<meta property="og:title" content="${title}" />`,
+    `<meta property="og:description" content="${description}" />`,
+    `<meta property="og:type" content="website" />`,
+    `<meta name="twitter:card" content="summary_large_image" />`,
+    `<meta name="twitter:title" content="${title}" />`,
+    `<meta name="twitter:description" content="${description}" />`,
+  ];
+  if (image) {
+    tags.push(`<meta property="og:image" content="${image}" />`);
+    tags.push(`<meta name="twitter:image" content="${image}" />`);
+  }
+  if (url) {
+    tags.push(`<meta property="og:url" content="${url}" />`);
+  }
+  return tags.join('\n');
+}


### PR DESCRIPTION
## Summary
- add undo/redo history with persistence to editor store
- wire toolbar actions to copy meta, export PNG and save presets
- introduce meta-tag builder and update docs/tests

## Screenshots/GIF
(none)

## Docs Updated
- [x] docs/log/2025-08-25.md
- [x] docs/dev_doc.md
- [x] README.md

## Tests
- [x] Unit
- [x] Component
- [ ] E2E

## Checklist
- [ ] A11y considered
- [ ] Fallbacks & errors handled
- [ ] Env vars documented (if any)


------
https://chatgpt.com/codex/tasks/task_e_68ac366c6cf8832b8f15162a7d7659dd