### PR TITLE
feat: add error boundary and toast notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Aplicação Next.js para criar imagens Open Graph personalizadas. Utiliza React,
 - Tailwind CSS
 - Zustand para estado global
 - NextAuth para autenticação
+- Sistema de toasts para notificações e Error Boundary para capturar falhas
 - Jest e Testing Library para testes
 
 ## Instalação e Uso
@@ -28,7 +29,7 @@ pnpm dev
   - `page.tsx`: página principal com editor e preview
   - `api/auth/[...nextauth]/route.ts`: rota de autenticação NextAuth
 - `components/`: componentes reutilizáveis
-  - `Providers.tsx`: wrapper com SessionProvider
+  - `Providers.tsx`: wrapper com SessionProvider e ToastProvider
   - `AuthButtons.tsx`: botões de login/logout
   - `CanvasStage.tsx`: preview da imagem OG
   - `EditorControls.tsx`: formulário para editar conteúdo

--- a/__tests__/ErrorBoundary.test.tsx
+++ b/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ErrorBoundary from '../components/ErrorBoundary';
+import { toast } from '../components/ToastProvider';
+
+jest.mock('../components/ToastProvider', () => ({
+  toast: jest.fn(),
+}));
+
+function Boom() {
+  throw new Error('boom');
+}
+
+test('renders fallback on error', () => {
+  render(
+    <ErrorBoundary fallback={<div>fallback</div>}>
+      <Boom />
+    </ErrorBoundary>
+  );
+  expect(screen.getByText('fallback')).toBeInTheDocument();
+  expect(toast).toHaveBeenCalled();
+});

--- a/app/(editor)/page.tsx
+++ b/app/(editor)/page.tsx
@@ -1,5 +1,10 @@
 import EditorShell from "components/editor/EditorShell";
+import ErrorBoundary from "components/ErrorBoundary";
 
 export default function Page() {
-  return <EditorShell />;
+  return (
+    <ErrorBoundary>
+      <EditorShell />
+    </ErrorBoundary>
+  );
 }

--- a/components/CanvasStage.tsx
+++ b/components/CanvasStage.tsx
@@ -4,6 +4,7 @@ import { useEditorStore } from 'lib/editorStore';
 import { useEffect, useState } from 'react';
 import { invertImageColors, blobToDataURL } from 'lib/images';
 import { removeImageBackground } from 'lib/removeBg';
+import { toast } from './ToastProvider';
 
 /**
  * A simple visual representation of the generated Open Graph image. This
@@ -58,7 +59,8 @@ export default function CanvasStage() {
           setLogoDataUrl(source as string);
         }
       } catch (e) {
-        console.error(e);
+        const message = e instanceof Error ? e.message : 'Erro ao processar a imagem.';
+        toast({ message, variant: 'error' });
         if (!cancelled) {
           setLogoDataUrl(undefined);
         }
@@ -90,7 +92,7 @@ export default function CanvasStage() {
         />
       )}
       {/* Overlay to darken/lighten banner for contrast */}
-      {bannerUrl && <div className={`absolute inset-0 ${theme === 'dark' ? 'bg-black/50' : 'bg-white/60'}`} />} 
+      {bannerUrl && <div className={`absolute inset-0 ${theme === 'dark' ? 'bg-black/50' : 'bg-white/60'}`} />}
       {/* Content container */}
       <div
         className={`absolute inset-0 flex flex-col justify-center px-12 py-8 space-y-4 ${layoutClasses}`}

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { Component, ReactNode } from "react";
+import { toast } from "./ToastProvider";
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error) {
+    toast({ message: error.message || "Unexpected error", variant: "error" });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? <div>Algo deu errado.</div>;
+    }
+    return this.props.children;
+  }
+}

--- a/components/ExportControls.tsx
+++ b/components/ExportControls.tsx
@@ -4,6 +4,7 @@ import { useEditorStore } from 'lib/editorStore';
 import { useState } from 'react';
 import { exportElementAsPng, ImageSize } from 'lib/images';
 import { generateRandomStyle, type RandomStyle } from 'lib/randomStyle';
+import { toast } from './ToastProvider';
 
 /**
  * Buttons to export the generated Open Graph image and copy the associated
@@ -31,25 +32,26 @@ export default function ExportControls() {
     ].join('\n');
     try {
       await navigator.clipboard.writeText(tags);
-      alert('Tags OG copiadas para a área de transferência!');
+      toast({ message: 'Tags OG copiadas para a área de transferência!' });
     } catch (err) {
-      console.error(err);
-      alert('Falha ao copiar as tags OG.');
+      const message = err instanceof Error ? err.message : 'Falha ao copiar as tags OG.';
+      toast({ message, variant: 'error' });
     }
   };
 
   const handleExport = async () => {
     const element = document.getElementById('og-canvas');
     if (!element) {
-      alert('Não foi possível encontrar o canvas para exportação.');
+      toast({ message: 'Não foi possível encontrar o canvas para exportação.', variant: 'error' });
       return;
     }
     try {
       const size = sizePresets[selectedSize];
       await exportElementAsPng(element, size, `og-image-${selectedSize}.png`);
+      toast({ message: 'Imagem exportada.' });
     } catch (err) {
-      console.error(err);
-      alert('Falha ao exportar a imagem.');
+      const message = err instanceof Error ? err.message : 'Falha ao exportar a imagem.';
+      toast({ message, variant: 'error' });
     }
   };
 

--- a/components/MetadataPanel.tsx
+++ b/components/MetadataPanel.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useMetadataStore } from 'lib/metadataStore';
 import { useEditorStore } from 'lib/editorStore';
+import { toast } from './ToastProvider';
 
 /**
  * Panel for editing metadata related to the current Open Graph image. By
@@ -43,6 +44,7 @@ export default function MetadataPanel() {
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to fetch metadata';
       setWarnings([message]);
+      toast({ message, variant: 'error' });
     }
   }
 

--- a/components/Providers.tsx
+++ b/components/Providers.tsx
@@ -3,11 +3,16 @@
 import { SessionProvider } from 'next-auth/react';
 import type { Session } from 'next-auth';
 import { PropsWithChildren } from 'react';
+import ToastProvider from './ToastProvider';
 
 /**
  * Global providers used by the app. Includes NextAuth's SessionProvider and any other
  * client-side context providers. You can add additional providers here (e.g. ThemeProvider).
  */
 export default function Providers({ children, session }: PropsWithChildren<{ session?: Session | null }>) {
-  return <SessionProvider session={session}>{children}</SessionProvider>;
+  return (
+    <SessionProvider session={session}>
+      <ToastProvider>{children}</ToastProvider>
+    </SessionProvider>
+  );
 }

--- a/components/ToastProvider.tsx
+++ b/components/ToastProvider.tsx
@@ -1,0 +1,48 @@
+"use client";
+import { ReactNode, useEffect, useState } from "react";
+
+export type Toast = {
+  id: number;
+  message: string;
+  variant?: "default" | "error";
+};
+
+let pushToast: ((toast: Toast) => void) | undefined;
+
+export function toast(opts: { message: string; variant?: "default" | "error" }) {
+  if (pushToast) {
+    pushToast({ id: Date.now(), ...opts });
+  }
+}
+
+export default function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  useEffect(() => {
+    pushToast = (toast: Toast) => {
+      setToasts((prev) => [...prev, toast]);
+      setTimeout(() => {
+        setToasts((prev) => prev.filter((t) => t.id !== toast.id));
+      }, 4000);
+    };
+    return () => {
+      pushToast = undefined;
+    };
+  }, []);
+
+  return (
+    <>
+      {children}
+      <div className="fixed top-4 right-4 z-50 space-y-2">
+        {toasts.map((t) => (
+          <div
+            key={t.id}
+            className={`rounded px-4 py-2 text-sm shadow text-white ${t.variant === "error" ? "bg-red-600" : "bg-gray-800"}`}
+          >
+            {t.message}
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/components/editor/CanvasStage.tsx
+++ b/components/editor/CanvasStage.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
-import { useEditorStore } from "../../state/editorStore";
+import { useEditorStore } from 'lib/editorStore';
 
 export default function CanvasStage() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);

--- a/components/editor/panels/CanvasPanel.tsx
+++ b/components/editor/panels/CanvasPanel.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEditorStore } from "../../../state/editorStore";
+import { useEditorStore } from 'lib/editorStore';
 
 export default function CanvasPanel() {
   const {

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -393,4 +393,12 @@ pnpm build
 
 ---
 
+## 18) Error Handling
+
+* `ErrorBoundary` envolve o `EditorShell` exibindo um fallback amigável.
+* `ToastProvider` fornece notificações para falhas em remoção de fundo, exportação e busca de metadata.
+
+---
+
 **End of base doc.**
+

--- a/docs/log/2025-08-25.md
+++ b/docs/log/2025-08-25.md
@@ -1,0 +1,9 @@
+# 2025-08-25
+
+## Summary
+- Add error boundary and toast notifications for editor operations.
+
+## Changed
+- Wrapped `EditorShell` with `ErrorBoundary`.
+- Added `ToastProvider` and replaced alerts/console errors with toasts.
+- Surfaced errors from image processing, export and metadata fetch.


### PR DESCRIPTION
## Summary
- wrap EditorShell with ErrorBoundary
- add ToastProvider and surface errors for image processing, export and metadata fetch
- replace alerts and console errors with toasts

## Docs Updated
- [x] docs/log/2025-08-25.md
- [x] docs/dev_doc.md
- [x] README.md

## Tests
- [ ] `pnpm typecheck` *(fails: Command "typecheck" not found)*
- [x] `pnpm lint`
- [x] `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac367ac010832bb07f8fa36fc21c85