### PR TITLE
feat: improve editor accessibility and keyboard controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ pnpm dev
 - `types/next-auth.d.ts`: tipagens adicionais para sessão
 - `tailwind.config.ts` e `postcss.config.js`: configuração de estilos
 
+## Atalhos de Teclado
+
+- **Cmd/Ctrl+Z**: desfazer
+- **Cmd/Ctrl+Shift+Z**: refazer
+- **Cmd/Ctrl+C**: copiar metatags
+- **Cmd/Ctrl+S**: salvar
+- **Setas**: mover o logo
+- **Shift+Setas para cima/baixo**: redimensionar o logo
+
 ## Variáveis de Ambiente
 
 O arquivo `.env.example` lista todas as variáveis necessárias. Copie para `.env.local` e complete com suas credenciais:

--- a/__tests__/canvas-keyboard.test.tsx
+++ b/__tests__/canvas-keyboard.test.tsx
@@ -1,0 +1,21 @@
+import { render, fireEvent, screen } from '@testing-library/react';
+import CanvasStage from '../components/CanvasStage';
+import { useEditorStore } from '../lib/editorStore';
+
+describe('CanvasStage keyboard controls', () => {
+  beforeEach(() => {
+    useEditorStore.setState({ logoPosition: { x: 50, y: 50 }, logoScale: 1 });
+  });
+
+  it('moves logo with arrow keys and scales with Shift+Arrow', () => {
+    render(<CanvasStage />);
+    const stage = screen.getByRole('img', { name: 'OG image preview' });
+    stage.focus();
+
+    fireEvent.keyDown(stage, { key: 'ArrowRight' });
+    expect(useEditorStore.getState().logoPosition.x).toBe(51);
+
+    fireEvent.keyDown(stage, { key: 'ArrowUp', shiftKey: true });
+    expect(useEditorStore.getState().logoScale).toBeCloseTo(1.05);
+  });
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -30,6 +30,6 @@
 }
 
 @layer components {
-  .btn { @apply px-3 py-1.5 rounded-lg border bg-muted hover:bg-muted/80 text-sm; }
+  .btn { @apply px-3 py-1.5 rounded-lg border bg-muted hover:bg-muted/80 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2; }
   .btn-primary { @apply bg-primary text-primary-foreground hover:bg-primary/90; }
 }

--- a/components/CanvasStage.tsx
+++ b/components/CanvasStage.tsx
@@ -23,6 +23,8 @@ export default function CanvasStage() {
     logoUrl,
     logoPosition,
     logoScale,
+    setLogoPosition,
+    setLogoScale,
     invertLogo,
     removeLogoBg,
     maskLogo
@@ -74,11 +76,35 @@ export default function CanvasStage() {
   const themeClasses = theme === 'dark' ? 'bg-gray-900 text-white' : 'bg-white text-gray-900';
   const layoutClasses = layout === 'center' ? 'items-center text-center' : 'items-start text-left';
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (
+      e.key === 'ArrowUp' ||
+      e.key === 'ArrowDown' ||
+      e.key === 'ArrowLeft' ||
+      e.key === 'ArrowRight'
+    ) {
+      e.preventDefault();
+      if (e.shiftKey && (e.key === 'ArrowUp' || e.key === 'ArrowDown')) {
+        const delta = e.key === 'ArrowUp' ? 0.05 : -0.05;
+        const next = Math.min(3, Math.max(0.2, logoScale + delta));
+        setLogoScale(next);
+      } else {
+        const dx = e.key === 'ArrowLeft' ? -1 : e.key === 'ArrowRight' ? 1 : 0;
+        const dy = e.key === 'ArrowUp' ? -1 : e.key === 'ArrowDown' ? 1 : 0;
+        setLogoPosition(logoPosition.x + dx, logoPosition.y + dy);
+      }
+    }
+  };
+
   return (
     <div
       id="og-canvas"
-      className={`relative w-full h-0 pt-[52.5%] overflow-hidden rounded-lg shadow-md border ${themeClasses}`}
+      className={`relative w-full h-0 pt-[52.5%] overflow-hidden rounded-lg shadow-md border ${themeClasses} focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring`}
       style={{ borderColor: accentColor }}
+      tabIndex={0}
+      role="img"
+      aria-label="OG image preview"
+      onKeyDown={handleKeyDown}
     >
       {/* Banner */}
       {bannerUrl && (

--- a/components/editor/CanvasStage.tsx
+++ b/components/editor/CanvasStage.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
-import { useEditorStore } from "../../state/editorStore";
+import { useEditorStore } from "lib/editorStore";
 
 export default function CanvasStage() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -46,7 +46,12 @@ export default function CanvasStage() {
   }, [zoom, theme, layout, accentColor]);
 
   return (
-    <div ref={containerRef} className="flex h-full w-full items-center justify-center overflow-hidden">
+    <div
+      ref={containerRef}
+      className="flex h-full w-full items-center justify-center overflow-hidden"
+      role="img"
+      aria-label="Canvas preview"
+    >
       <canvas
         ref={canvasRef}
         width={base.w}

--- a/components/editor/Inspector.tsx
+++ b/components/editor/Inspector.tsx
@@ -18,18 +18,36 @@ export default function Inspector() {
 
   return (
     <div className="h-full rounded-2xl border bg-card p-3 shadow-sm">
-      <div className="mb-4 flex gap-2 border-b pb-2 text-sm">
+      <div
+        className="mb-4 flex gap-2 border-b pb-2 text-sm"
+        role="tablist"
+        aria-label="Editor panels"
+      >
         {tabs.map(tab => (
           <button
             key={tab.id}
-            className={`px-2 py-1 ${active === tab.id ? "border-b-2" : ""}`}
+            id={`tab-${tab.id}`}
+            role="tab"
+            aria-selected={active === tab.id}
+            aria-controls={`panel-${tab.id}`}
+            className={`px-2 py-1 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring rounded-md ${
+              active === tab.id ? "border-b-2" : ""
+            }`}
             onClick={() => setActive(tab.id)}
           >
             {tab.label}
           </button>
         ))}
       </div>
-      <ActivePanel />
+      <div
+        id={`panel-${active}`}
+        role="tabpanel"
+        aria-labelledby={`tab-${active}`}
+        tabIndex={0}
+        className="outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring"
+      >
+        <ActivePanel />
+      </div>
     </div>
   );
 }

--- a/components/editor/panels/CanvasPanel.tsx
+++ b/components/editor/panels/CanvasPanel.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEditorStore } from "../../../state/editorStore";
+import { useEditorStore } from "lib/editorStore";
 
 export default function CanvasPanel() {
   const {

--- a/components/editor/panels/ExportPanel.tsx
+++ b/components/editor/panels/ExportPanel.tsx
@@ -3,12 +3,22 @@ export default function ExportPanel() {
   return (
     <section className="space-y-3">
       <div className="grid grid-cols-3 gap-2">
-        <button className="btn">1200×630</button>
-        <button className="btn">1600×900</button>
-        <button className="btn">1920×1005</button>
+        <button className="btn" aria-label="Export size 1200 by 630">
+          1200×630
+        </button>
+        <button className="btn" aria-label="Export size 1600 by 900">
+          1600×900
+        </button>
+        <button className="btn" aria-label="Export size 1920 by 1005">
+          1920×1005
+        </button>
       </div>
-      <button className="btn btn-primary w-full">Export PNG</button>
-      <button className="btn w-full">Copy Meta</button>
+      <button className="btn btn-primary w-full" aria-label="Export image as PNG">
+        Export PNG
+      </button>
+      <button className="btn w-full" aria-label="Copy meta tags">
+        Copy Meta
+      </button>
     </section>
   );
 }

--- a/components/editor/panels/LogoPanel.tsx
+++ b/components/editor/panels/LogoPanel.tsx
@@ -3,22 +3,53 @@ export default function LogoPanel() {
   return (
     <section className="space-y-3">
       <div className="flex items-center gap-2">
-        <input type="file" accept="image/png,image/svg+xml" />
-        <button className="btn">Paste</button>
-        <button className="btn">From URL</button>
+        <label htmlFor="logo-upload" className="sr-only">
+          Upload logo
+        </label>
+        <input
+          id="logo-upload"
+          type="file"
+          accept="image/png,image/svg+xml"
+        />
+        <button className="btn" aria-label="Paste logo from clipboard">
+          Paste
+        </button>
+        <button className="btn" aria-label="Load logo from URL">
+          From URL
+        </button>
       </div>
       <div className="grid grid-cols-3 gap-2">
-        <button className="btn">Remove BG</button>
-        <button className="btn">Invert B/W</button>
-        <button className="btn">Mask: Circle</button>
+        <button className="btn" aria-label="Remove background from logo">
+          Remove BG
+        </button>
+        <button className="btn" aria-label="Invert logo colors">
+          Invert B/W
+        </button>
+        <button className="btn" aria-label="Mask logo as circle">
+          Mask: Circle
+        </button>
       </div>
       <div>
-        <label className="text-sm">Scale</label>
-        <input type="range" min={0.2} max={3} step={0.01} className="w-full" />
+        <label htmlFor="logo-scale" className="text-sm">
+          Scale
+        </label>
+        <input
+          id="logo-scale"
+          type="range"
+          min={0.2}
+          max={3}
+          step={0.01}
+          className="w-full"
+          aria-labelledby="logo-scale"
+        />
       </div>
       <div className="grid grid-cols-2 gap-2">
-        <button className="btn">Reset</button>
-        <button className="btn">Center</button>
+        <button className="btn" aria-label="Reset logo adjustments">
+          Reset
+        </button>
+        <button className="btn" aria-label="Center logo on canvas">
+          Center
+        </button>
       </div>
     </section>
   );

--- a/components/editor/panels/TextPanel.tsx
+++ b/components/editor/panels/TextPanel.tsx
@@ -11,9 +11,9 @@ export default function TextPanel() {
         <textarea className="mt-1 w-full rounded-lg border bg-background px-3 py-2" rows={3} placeholder="Short description" />
       </label>
       <div className="grid grid-cols-3 gap-2">
-        <button className="btn">XS</button>
-        <button className="btn">MD</button>
-        <button className="btn">XL</button>
+        <button className="btn" aria-label="Extra small title size">XS</button>
+        <button className="btn" aria-label="Medium title size">MD</button>
+        <button className="btn" aria-label="Extra large title size">XL</button>
       </div>
     </section>
   );

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -189,7 +189,7 @@ http://localhost:3000/api/auth/callback/<provider>
 **Accessibility/UX**
 
 * Labels + `aria-describedby` for form fields; focus rings; toasts on success.
-* Keyboard: `Ctrl/Cmd+S` export, `Ctrl/Cmd+C` meta, `R` Surprise, `1/2/3` sizes.
+* Keyboard: `Ctrl/Cmd+S` export, `Ctrl/Cmd+C` meta, `R` Surprise, `1/2/3` sizes, arrow keys move logo, `Shift+Arrow` scales logo.
 
 ---
 

--- a/docs/log/2025-08-25.md
+++ b/docs/log/2025-08-25.md
@@ -1,0 +1,9 @@
+# 2025-08-25
+
+## Summary
+- Improve editor accessibility and keyboard support.
+
+## Changed
+- Added ARIA roles and labels to editor controls.
+- Enabled arrow key movement and scaling for logos.
+- Documented keyboard shortcuts and accessibility updates.


### PR DESCRIPTION
## Summary
- add ARIA roles and labels to editor controls
- support arrow key logo movement and scaling
- document shortcuts and add unit test

## Screenshots/GIF
- n/a

## Docs Updated
- [x] docs/log/2025-08-25.md
- [x] docs/dev_doc.md
- [x] README.md

## Tests
- [x] Unit
- [ ] Component
- [ ] E2E

## Checklist
- [x] A11y considered
- [ ] Fallbacks & errors handled
- [ ] Env vars documented (if any)

------
https://chatgpt.com/codex/tasks/task_e_68ac367661c4832b9f0931b2b726d5e3