### PR TITLE
feat: add 2x export and font loading guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pnpm dev
   - `AuthButtons.tsx`: botões de login/logout
   - `CanvasStage.tsx`: preview da imagem OG
   - `EditorControls.tsx`: formulário para editar conteúdo
-  - `ExportControls.tsx`: exportação de PNG e metatags (export em desenvolvimento)
+  - `ExportControls.tsx`: exportação de PNG (presets @1x/@2x) e metatags
 - `lib/`:
   - `authOptions.ts`: configuração do NextAuth
   - `editorStore.ts`: estado global com Zustand
@@ -51,7 +51,6 @@ Preencha cada chave com valores obtidos nos provedores OAuth (Google, GitHub, et
 
 ## Roadmap e Recursos Futuros
 
-- Exportação direta para PNG com alta resolução
 - Presets automáticos de layout e cores ("Surpreenda‑me")
 - Persistência das configurações no `localStorage`
 - Página de login personalizada

--- a/__tests__/export-controls.test.tsx
+++ b/__tests__/export-controls.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ExportControls from '../components/ExportControls';
+import { exportElementAsPng } from '../lib/images';
+import { useEditorStore } from '../lib/editorStore';
+
+jest.mock('../lib/images', () => ({
+  exportElementAsPng: jest.fn().mockResolvedValue(undefined),
+}));
+
+beforeEach(() => {
+  useEditorStore.setState({
+    title: '',
+    subtitle: '',
+    theme: 'light',
+    layout: 'left',
+    accentColor: '#3b82f6',
+    bannerUrl: undefined,
+    logoUrl: undefined,
+    logoPosition: { x: 0, y: 0 },
+    logoScale: 1,
+    invertLogo: false,
+    removeLogoBg: false,
+    maskLogo: false,
+  });
+  document.body.innerHTML = '<div id="og-canvas"></div>';
+});
+
+describe('ExportControls', () => {
+  it('exports using selected pixel ratio', async () => {
+    render(<ExportControls />);
+    fireEvent.change(screen.getByLabelText(/resolução/i), { target: { value: '2' } });
+    fireEvent.click(screen.getByText(/Exportar PNG/i));
+    await waitFor(() => {
+      expect(exportElementAsPng).toHaveBeenCalledWith(
+        expect.any(HTMLElement),
+        expect.any(Object),
+        expect.stringContaining('@2x'),
+        { pixelRatio: 2 }
+      );
+    });
+  });
+});

--- a/__tests__/images.test.ts
+++ b/__tests__/images.test.ts
@@ -1,4 +1,9 @@
-import { blobToDataURL, invertImageColors } from '../lib/images';
+import { blobToDataURL, invertImageColors, exportElementAsPng } from '../lib/images';
+import * as htmlToImage from 'html-to-image';
+
+jest.mock('html-to-image', () => ({
+  toPng: jest.fn().mockResolvedValue('data:image/png;base64,'),
+}));
 
 describe('image utilities', () => {
   it('converts Blob to data URL', async () => {
@@ -21,9 +26,10 @@ describe('image utilities', () => {
       width: 0,
       height: 0,
     } as any;
+    const createElement = document.createElement.bind(document);
     jest.spyOn(document, 'createElement').mockImplementation((tag: string) => {
       if (tag === 'canvas') return mockCanvas;
-      return document.createElement(tag) as any;
+      return createElement(tag);
     });
 
     class MockImage {
@@ -41,5 +47,32 @@ describe('image utilities', () => {
 
     const inverted = await invertImageColors(redPixel);
     expect(inverted.startsWith('data:image/png;base64,')).toBe(true);
+  });
+
+  it('waits for fonts and respects pixelRatio when exporting', async () => {
+    const element = document.createElement('div');
+    element.getBoundingClientRect = () => ({ width: 100, height: 50 } as any);
+
+    let resolveFonts: () => void;
+    // @ts-ignore
+    document.fonts = { ready: new Promise<void>((r) => (resolveFonts = r)) };
+
+    const exportPromise = exportElementAsPng(
+      element,
+      { width: 200, height: 100 },
+      'test.png',
+      { pixelRatio: 2 }
+    );
+
+    const toPngMock = htmlToImage.toPng as jest.Mock;
+    expect(toPngMock).not.toHaveBeenCalled();
+
+    resolveFonts();
+    await exportPromise;
+
+    expect(toPngMock).toHaveBeenCalledWith(
+      element,
+      expect.objectContaining({ pixelRatio: 2 })
+    );
   });
 });

--- a/components/ExportControls.tsx
+++ b/components/ExportControls.tsx
@@ -18,6 +18,7 @@ export default function ExportControls() {
   };
 
   const [selectedSize, setSelectedSize] = useState<keyof typeof sizePresets>('1200x630');
+  const [selectedScale, setSelectedScale] = useState(1);
   const { title, subtitle, theme, layout, accentColor, setTheme, setLayout, setAccentColor } = useEditorStore();
   const [prevStyle, setPrevStyle] = useState<RandomStyle | null>(null);
 
@@ -46,7 +47,12 @@ export default function ExportControls() {
     }
     try {
       const size = sizePresets[selectedSize];
-      await exportElementAsPng(element, size, `og-image-${selectedSize}.png`);
+      await exportElementAsPng(
+        element,
+        size,
+        `og-image-${selectedSize}@${selectedScale}x.png`,
+        { pixelRatio: selectedScale }
+      );
     } catch (err) {
       console.error(err);
       alert('Falha ao exportar a imagem.');
@@ -81,6 +87,15 @@ export default function ExportControls() {
             {key}
           </option>
         ))}
+      </select>
+      <select
+        aria-label="resolução"
+        value={selectedScale}
+        onChange={(e) => setSelectedScale(Number(e.target.value))}
+        className="rounded-md border border-gray-300 bg-white px-2 py-2 text-sm"
+      >
+        <option value={1}>@1x</option>
+        <option value={2}>@2x</option>
       </select>
       <button
         onClick={handleExport}

--- a/components/editor/CanvasStage.tsx
+++ b/components/editor/CanvasStage.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
-import { useEditorStore } from "../../state/editorStore";
+import { useEditorStore } from "../../lib/editorStore";
 
 export default function CanvasStage() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);

--- a/components/editor/panels/CanvasPanel.tsx
+++ b/components/editor/panels/CanvasPanel.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEditorStore } from "../../../state/editorStore";
+import { useEditorStore } from "../../../lib/editorStore";
 
 export default function CanvasPanel() {
   const {

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -56,7 +56,7 @@ OGGenerator is a one‑page (expandable) app to **compose Open Graph images** wi
 │  ├─ lib/
 │  │  ├─ auth.ts                                  # NextAuth config
 │  │  ├─ storage.ts                               # KV/S3 helpers
-│  │  ├─ images.ts                                # canvas helpers (scale/export/invert)
+│  │  ├─ images.ts                                # canvas helpers (scale/export/invert, font-ready @2x)
 │  │  ├─ removeBg.ts                              # WASM loader + pipeline
 │  │  └─ meta.ts                                  # build OG/Twitter meta
 │  ├─ state/
@@ -387,7 +387,7 @@ pnpm build
 ## 17) Troubleshooting
 
 * **OAuth callback error**: ensure provider console has the exact redirect URL.
-* **Fonts not applied in export**: use `document.fonts.ready` and/or pre‑rasterize text.
+* **Fonts not applied in export**: the export utility awaits `document.fonts.ready`, but ensure custom fonts are loaded.
 * **WASM background removal slow**: run in Worker and lazy‑load the model (\~5–15MB). Cache after first run.
 * **SVG injection risk**: sanitize or rasterize into canvas before any edit.
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -12,3 +12,4 @@ This document records major milestones in the project.
 - Added tests covering pages, images, and authentication.
 - Added NextAuth session typing and refined TypeScript configuration.
 - Fixed OAuth callback error handling for LinkedIn.
+- Added font loading guard and @2x export options with size presets; fixed CanvasStage store import.

--- a/lib/images.ts
+++ b/lib/images.ts
@@ -12,11 +12,18 @@ export interface ImageSize {
  * @param size    Desired output resolution
  * @param filename Name for the downloaded file
  */
+export interface ExportOptions {
+  pixelRatio?: number;
+}
+
 export async function exportElementAsPng(
   element: HTMLElement,
   size: ImageSize,
-  filename = 'og-image.png'
+  filename = 'og-image.png',
+  { pixelRatio = 1 }: ExportOptions = {}
 ): Promise<void> {
+  await document.fonts.ready;
+
   const { width: originalWidth, height: originalHeight } =
     element.getBoundingClientRect();
 
@@ -32,7 +39,7 @@ export async function exportElementAsPng(
       width: `${originalWidth}px`,
       height: `${originalHeight}px`
     },
-    pixelRatio: 1
+    pixelRatio
   });
 
   const link = document.createElement('a');


### PR DESCRIPTION
## Summary
- wait for `document.fonts.ready` and allow pixel ratio for high-res PNG export
- expose @1x/@2x scale presets in export controls
- fix editor store imports in canvas components

## Screenshots/GIF
(none)

## Docs Updated
- [x] docs/log.md
- [x] docs/dev_doc.md
- [x] README.md

## Tests
- [x] Unit
- [x] Component
- [ ] E2E

## Checklist
- [ ] A11y considered
- [ ] Fallbacks & errors handled
- [ ] Env vars documented (if any)


------
https://chatgpt.com/codex/tasks/task_e_68ac3673b1c0832b9543785bc36a1a3f