### PR TITLE
feat: add meta tag builder and clipboard actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@ pnpm dev
   - `AuthButtons.tsx`: botões de login/logout
   - `CanvasStage.tsx`: preview da imagem OG
   - `EditorControls.tsx`: formulário para editar conteúdo
-  - `ExportControls.tsx`: exportação de PNG e metatags (export em desenvolvimento)
+  - `ExportControls.tsx`: exportação de PNG e cópia de metatags
 - `lib/`:
   - `authOptions.ts`: configuração do NextAuth
   - `editorStore.ts`: estado global com Zustand
+  - `metaTags.ts`: utilitário para gerar tags OG/Twitter
 - `types/next-auth.d.ts`: tipagens adicionais para sessão
 - `tailwind.config.ts` e `postcss.config.js`: configuração de estilos
 

--- a/__tests__/metaTags.test.ts
+++ b/__tests__/metaTags.test.ts
@@ -1,0 +1,26 @@
+import { buildMetaTags } from '../lib/metaTags';
+
+describe('buildMetaTags', () => {
+  it('creates OG and Twitter meta tags', () => {
+    const tags = buildMetaTags({
+      title: 'Title',
+      description: 'Desc',
+      image: 'https://example.com/img.png',
+      url: 'https://example.com',
+      siteName: 'Example',
+      twitterSite: '@example'
+    });
+
+    expect(tags).toContain('<meta property="og:title" content="Title" />');
+    expect(tags).toContain('<meta property="og:description" content="Desc" />');
+    expect(tags).toContain('<meta property="og:image" content="https://example.com/img.png" />');
+    expect(tags).toContain('<meta name="twitter:card" content="summary_large_image" />');
+    expect(tags).toContain('<meta name="twitter:image" content="https://example.com/img.png" />');
+  });
+
+  it('omits tags for missing fields', () => {
+    const tags = buildMetaTags({ title: 'Only' });
+    expect(tags).not.toContain('og:description');
+    expect(tags).not.toContain('og:image');
+  });
+});

--- a/__tests__/toolbar-shortcuts.test.tsx
+++ b/__tests__/toolbar-shortcuts.test.tsx
@@ -3,13 +3,17 @@ import Toolbar from '../components/editor/Toolbar';
 
 describe('Toolbar shortcuts', () => {
   let logSpy: jest.SpyInstance;
+  let writeText: jest.Mock;
 
   beforeEach(() => {
     logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    writeText = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
   });
 
   afterEach(() => {
     logSpy.mockRestore();
+    writeText.mockReset();
   });
 
   it('handles undo via click and shortcut', () => {
@@ -31,9 +35,9 @@ describe('Toolbar shortcuts', () => {
   it('handles copy meta via click and shortcut', () => {
     render(<Toolbar />);
     fireEvent.click(screen.getByRole('button', { name: 'Copy Meta' }));
-    expect(logSpy).toHaveBeenLastCalledWith('copy meta');
+    expect(writeText).toHaveBeenCalledTimes(1);
     fireEvent.keyDown(window, { key: 'c', ctrlKey: true });
-    expect(logSpy).toHaveBeenLastCalledWith('copy meta');
+    expect(writeText).toHaveBeenCalledTimes(2);
   });
 
   it('handles save via click and shortcut', () => {

--- a/components/ExportControls.tsx
+++ b/components/ExportControls.tsx
@@ -4,6 +4,7 @@ import { useEditorStore } from 'lib/editorStore';
 import { useState } from 'react';
 import { exportElementAsPng, ImageSize } from 'lib/images';
 import { generateRandomStyle, type RandomStyle } from 'lib/randomStyle';
+import { buildMetaTags } from 'lib/metaTags';
 
 /**
  * Buttons to export the generated Open Graph image and copy the associated
@@ -23,12 +24,7 @@ export default function ExportControls() {
 
 
   const handleCopyMeta = async () => {
-    const tags = [
-      `<meta property="og:title" content="${title}" />`,
-      `<meta property="og:description" content="${subtitle}" />`,
-      `<meta property="og:type" content="website" />`,
-      `<meta name="twitter:card" content="summary_large_image" />`
-    ].join('\n');
+    const tags = buildMetaTags({ title, description: subtitle });
     try {
       await navigator.clipboard.writeText(tags);
       alert('Tags OG copiadas para a área de transferência!');

--- a/components/editor/CanvasStage.tsx
+++ b/components/editor/CanvasStage.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
-import { useEditorStore } from "../../state/editorStore";
+import { useEditorStore } from "lib/editorStore";
 
 export default function CanvasStage() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);

--- a/components/editor/Toolbar.tsx
+++ b/components/editor/Toolbar.tsx
@@ -1,11 +1,17 @@
 "use client";
 
 import { useEffect } from "react";
+import { useEditorStore } from 'lib/editorStore';
+import { buildMetaTags } from 'lib/metaTags';
 
 export default function Toolbar() {
+  const { title, subtitle } = useEditorStore();
   const handleUndo = () => console.log("undo");
   const handleRedo = () => console.log("redo");
-  const handleCopyMeta = () => console.log("copy meta");
+  const handleCopyMeta = () => {
+    const tags = buildMetaTags({ title, description: subtitle });
+    navigator.clipboard.writeText(tags).then(() => console.log("copy meta")).catch(console.error);
+  };
   const handleExport = () => console.log("export");
   const handleSave = () => console.log("save");
 

--- a/components/editor/panels/CanvasPanel.tsx
+++ b/components/editor/panels/CanvasPanel.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEditorStore } from "../../../state/editorStore";
+import { useEditorStore } from "lib/editorStore";
 
 export default function CanvasPanel() {
   const {

--- a/components/editor/panels/ExportPanel.tsx
+++ b/components/editor/panels/ExportPanel.tsx
@@ -1,5 +1,16 @@
 "use client";
+
+import { useEditorStore } from 'lib/editorStore';
+import { buildMetaTags } from 'lib/metaTags';
+
 export default function ExportPanel() {
+  const { title, subtitle } = useEditorStore();
+
+  const handleCopyMeta = () => {
+    const tags = buildMetaTags({ title, description: subtitle });
+    navigator.clipboard.writeText(tags).catch(console.error);
+  };
+
   return (
     <section className="space-y-3">
       <div className="grid grid-cols-3 gap-2">
@@ -8,7 +19,7 @@ export default function ExportPanel() {
         <button className="btn">1920×1005</button>
       </div>
       <button className="btn btn-primary w-full">Export PNG</button>
-      <button className="btn w-full">Copy Meta</button>
+      <button className="btn w-full" onClick={handleCopyMeta}>Copy Meta</button>
     </section>
   );
 }

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -58,7 +58,7 @@ OGGenerator is a one‑page (expandable) app to **compose Open Graph images** wi
 │  │  ├─ storage.ts                               # KV/S3 helpers
 │  │  ├─ images.ts                                # canvas helpers (scale/export/invert)
 │  │  ├─ removeBg.ts                              # WASM loader + pipeline
-│  │  └─ meta.ts                                  # build OG/Twitter meta
+│  │  └─ metaTags.ts                              # build OG/Twitter meta tags
 │  ├─ state/
 │  │  └─ editorStore.ts                           # Zustand store (title, subtitle, theme, etc.)
 │  ├─ workers/

--- a/docs/log/2025-08-25.md
+++ b/docs/log/2025-08-25.md
@@ -1,0 +1,9 @@
+# 2025-08-25
+
+## Summary
+- Added meta tag builder util and wired copy-meta actions across controls and toolbar.
+
+## Changed
+- Introduced lib/metaTags.ts for OG/Twitter tags.
+- Export and toolbar now copy meta tags using util.
+- Added unit tests for meta tag builder and toolbar clipboard.

--- a/lib/metaTags.ts
+++ b/lib/metaTags.ts
@@ -1,0 +1,33 @@
+export interface MetaOptions {
+  title?: string;
+  description?: string;
+  image?: string;
+  url?: string;
+  siteName?: string;
+  twitterSite?: string;
+}
+
+/**
+ * Build a string of Open Graph and Twitter meta tags based on provided options.
+ */
+export function buildMetaTags({ title, description, image, url, siteName, twitterSite }: MetaOptions): string {
+  const tags: string[] = [];
+  if (title) {
+    tags.push(`<meta property="og:title" content="${title}" />`);
+    tags.push(`<meta name="twitter:title" content="${title}" />`);
+  }
+  if (description) {
+    tags.push(`<meta property="og:description" content="${description}" />`);
+    tags.push(`<meta name="twitter:description" content="${description}" />`);
+  }
+  tags.push('<meta property="og:type" content="website" />');
+  if (url) tags.push(`<meta property="og:url" content="${url}" />`);
+  if (siteName) tags.push(`<meta property="og:site_name" content="${siteName}" />`);
+  if (image) {
+    tags.push(`<meta property="og:image" content="${image}" />`);
+    tags.push(`<meta name="twitter:image" content="${image}" />`);
+  }
+  tags.push('<meta name="twitter:card" content="summary_large_image" />');
+  if (twitterSite) tags.push(`<meta name="twitter:site" content="${twitterSite}" />`);
+  return tags.join('\n');
+}


### PR DESCRIPTION
## Summary
- add `buildMetaTags` util for OG/Twitter tags
- wire copy-meta to use util in export controls, panel, and toolbar
- document meta tag helper and add unit tests

## Docs Updated
- [x] docs/log/2025-08-25.md
- [x] docs/dev_doc.md
- [x] README.md

## Tests
- [x] `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac367de824832b9fcb7db2a80acd5c