### PR TITLE
feat: escape HTML in meta tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Aplicação Next.js para criar imagens Open Graph personalizadas. Utiliza React,
 - Editor de logo com upload por arquivo, colagem ou URL
 - Remoção de fundo, inversão B/W e máscara circular do logo
 - Controles de escala e centralização do logo
+- Sanitização de campos de metadados
 
 ## Instalação e Uso
 
@@ -47,9 +48,24 @@ pnpm dev
 - `lib/`:
   - `authOptions.ts`: configuração do NextAuth
   - `editorStore.ts`: estado global com Zustand
+  - `meta.ts`: constrói e copia metatags com sanitização de HTML
   - `metaTags.ts`: utilitário para gerar tags OG/Twitter
-- `types/next-auth.d.ts`: tipagens adicionais para sessão
-- `tailwind.config.ts` e `postcss.config.js`: configuração de estilos
+  - `types/next-auth.d.ts`: tipagens adicionais para sessão
+  - `tailwind.config.ts` e `postcss.config.js`: configuração de estilos
+
+## Sanitização de Entrada
+
+Strings usadas em metatags passam por `escapeHtml` para evitar quebra de HTML e possíveis injeções.
+
+```ts
+import { buildMetaTags } from './lib/meta';
+
+const tags = buildMetaTags({
+  title: 'Tom & "Jerry" <3',
+  description: 'It\'s > all & fun',
+});
+// content="Tom &amp; &quot;Jerry&quot; &lt;3" etc.
+```
 
 ## Atalhos de Teclado
 

--- a/__tests__/meta.test.ts
+++ b/__tests__/meta.test.ts
@@ -21,4 +21,17 @@ describe('meta helpers', () => {
     const tags = buildMetaTags({ title: 'T', description: 'D', url: 'https://x.com' });
     expect(tags).toContain('<meta property="og:url" content="https://x.com" />');
   });
+
+  it('escapes special HTML characters', () => {
+    const tags = buildMetaTags({
+      title: 'Tom & "Jerry" <Best>',
+      description: 'It\'s > all "fun" & games',
+      image: 'img?id=1&mode=<',
+      url: 'https://x.com/?q=a&b',
+    });
+    expect(tags).toContain('<meta property="og:title" content="Tom &amp; &quot;Jerry&quot; &lt;Best&gt;" />');
+    expect(tags).toContain('<meta property="og:description" content="It&#39;s &gt; all &quot;fun&quot; &amp; games" />');
+    expect(tags).toContain('<meta property="og:image" content="img?id=1&amp;mode=&lt;" />');
+    expect(tags).toContain('<meta property="og:url" content="https://x.com/?q=a&amp;b" />');
+  });
 });

--- a/docs/log/2025-08-25.md
+++ b/docs/log/2025-08-25.md
@@ -1,7 +1,6 @@
 # 2025-08-25
 
 ## Summary
-<<<<<<< HEAD
 - Sanitize uploaded SVG logos and rasterize to PNG before processing.
 - Add error boundary and toast notifications for editor operations.
 - Added Metadata and Presets tabs to the inspector using existing panels.
@@ -14,6 +13,7 @@
 - ci: add docs guard and coverage
 - Added tests to raise coverage for random style generator and background removal utility.
 - Added meta tag builder util and wired copy-meta actions across controls and toolbar.
+- Escape HTML characters in meta tag fields to prevent injection.
 
 ## Changed
 - Added sanitizeSvg and svgToPng helpers.
@@ -52,3 +52,6 @@
 - Introduced lib/metaTags.ts for OG/Twitter tags.
 - Export and toolbar now copy meta tags using util.
 - Added unit tests for meta tag builder and toolbar clipboard.
+- lib/meta.ts
+- __tests__/meta.test.ts
+- README.md

--- a/lib/meta.ts
+++ b/lib/meta.ts
@@ -6,23 +6,42 @@ export interface MetaOptions {
 }
 
 /**
+ * Escape HTML special characters to prevent breaking out of attribute values.
+ */
+export function escapeHtml(str: string): string {
+  const map: Record<string, string> = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  };
+  return str.replace(/[&<>"']/g, (ch) => map[ch]);
+}
+
+/**
  * Build a block of Open Graph and Twitter meta tags.
  */
 export function buildMetaTags({ title, description, image, url }: MetaOptions): string {
+  const safeTitle = escapeHtml(title);
+  const safeDescription = escapeHtml(description);
+  const safeImage = image ? escapeHtml(image) : undefined;
+  const safeUrl = url ? escapeHtml(url) : undefined;
+
   const tags: string[] = [
-    `<meta property="og:title" content="${title}" />`,
-    `<meta property="og:description" content="${description}" />`,
+    `<meta property="og:title" content="${safeTitle}" />`,
+    `<meta property="og:description" content="${safeDescription}" />`,
     `<meta property="og:type" content="website" />`,
     `<meta name="twitter:card" content="summary_large_image" />`,
-    `<meta name="twitter:title" content="${title}" />`,
-    `<meta name="twitter:description" content="${description}" />`,
+    `<meta name="twitter:title" content="${safeTitle}" />`,
+    `<meta name="twitter:description" content="${safeDescription}" />`,
   ];
-  if (image) {
-    tags.push(`<meta property="og:image" content="${image}" />`);
-    tags.push(`<meta name="twitter:image" content="${image}" />`);
+  if (safeImage) {
+    tags.push(`<meta property="og:image" content="${safeImage}" />`);
+    tags.push(`<meta name="twitter:image" content="${safeImage}" />`);
   }
-  if (url) {
-    tags.push(`<meta property="og:url" content="${url}" />`);
+  if (safeUrl) {
+    tags.push(`<meta property="og:url" content="${safeUrl}" />`);
   }
   return tags.join('\n');
 }


### PR DESCRIPTION
## Summary
- sanitize meta tag fields to prevent HTML injection
- document input sanitization in README and logs

## Docs Updated
- [x] docs/log/2025-08-25.md
- [ ] docs/dev_doc.md
- [x] README.md

## Tests
- [x] `pnpm typecheck` *(fails: Command "typecheck" not found)*
- [x] `pnpm lint lib/meta.ts __tests__/meta.test.ts README.md docs/log/2025-08-25.md`
- [x] `pnpm test __tests__/meta.test.ts`
- [x] `pnpm dlx tsx scripts/docs-guard.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ac699ac3e8832ba25c090c61057ed6