### PR TITLE
feat: validate auth env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ cp .env.example .env.local
 
 Preencha cada chave com valores obtidos nos provedores OAuth (Google, GitHub, etc.) e defina um `NEXTAUTH_SECRET` forte.
 
+As variáveis são validadas em tempo de inicialização pelo arquivo `lib/env.ts` usando [Zod](https://github.com/colinhacks/zod). A aplicação exibirá erro e não iniciará caso qualquer variável obrigatória esteja ausente ou vazia.
+
 ## Testes
 
 Execute os testes unitários com cobertura e verifique se a documentação está atualizada:

--- a/__tests__/auth.test.ts
+++ b/__tests__/auth.test.ts
@@ -1,12 +1,79 @@
-import { authOptions } from '../lib/authOptions';
-
 describe('authOptions', () => {
+  const originalEnv = process.env;
+  const validEnv = {
+    GOOGLE_CLIENT_ID: 'id',
+    GOOGLE_CLIENT_SECRET: 'secret',
+    GITHUB_CLIENT_ID: 'id',
+    GITHUB_CLIENT_SECRET: 'secret',
+    LINKEDIN_CLIENT_ID: 'id',
+    LINKEDIN_CLIENT_SECRET: 'secret',
+    TWITTER_CONSUMER_KEY: 'key',
+    TWITTER_CONSUMER_SECRET: 'secret',
+    FACEBOOK_CLIENT_ID: 'id',
+    FACEBOOK_CLIENT_SECRET: 'secret',
+    INSTAGRAM_CLIENT_ID: 'id',
+    INSTAGRAM_CLIENT_SECRET: 'secret',
+    NEXTAUTH_SECRET: 'secret',
+  };
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv, ...validEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
   it('includes at least one provider', () => {
+    const { authOptions } = require('../lib/authOptions');
     expect(authOptions.providers).toBeDefined();
     expect(authOptions.providers?.length).toBeGreaterThan(0);
   });
 
   it('uses jwt session strategy', () => {
+    const { authOptions } = require('../lib/authOptions');
     expect(authOptions.session?.strategy).toBe('jwt');
+  });
+
+  it('jwt callback stores provider and user id', async () => {
+    const { authOptions } = require('../lib/authOptions');
+    const token = await authOptions.callbacks?.jwt?.({
+      token: {},
+      account: { provider: 'google' } as any,
+      user: { id: '123' } as any,
+    } as any);
+    expect(token).toEqual(expect.objectContaining({ provider: 'google', id: '123' }));
+  });
+
+  it('jwt callback leaves token untouched when account and user missing', async () => {
+    const { authOptions } = require('../lib/authOptions');
+    const token = await authOptions.callbacks?.jwt?.({ token: {} } as any);
+    expect(token).toEqual({});
+  });
+
+  it('session callback adds id and provider', async () => {
+    const { authOptions } = require('../lib/authOptions');
+    const session = await authOptions.callbacks?.session?.({
+      session: { user: {} } as any,
+      token: { id: '123', provider: 'google' } as any,
+    } as any);
+    expect(session.user).toEqual(expect.objectContaining({ id: '123', provider: 'google' }));
+  });
+
+  it('session callback returns session if user missing', async () => {
+    const { authOptions } = require('../lib/authOptions');
+    const session = await authOptions.callbacks?.session?.({
+      session: {} as any,
+      token: { id: '123', provider: 'google' } as any,
+    } as any);
+    expect(session).toEqual({});
+  });
+
+  it('throws when required env vars are missing', () => {
+    const { GOOGLE_CLIENT_ID, ...rest } = validEnv;
+    process.env = { ...originalEnv, ...rest };
+    jest.resetModules();
+    expect(() => require('../lib/authOptions')).toThrow();
   });
 });

--- a/__tests__/remove-bg.test.ts
+++ b/__tests__/remove-bg.test.ts
@@ -43,5 +43,14 @@ describe('removeImageBackground', () => {
     const { removeImageBackground } = await import('../lib/removeBg');
     await expect(removeImageBackground('img')).rejects.toThrow('fail');
   });
+
+  it('reuses existing worker on subsequent calls', async () => {
+    mockWorker({ dataUrl: 'again' });
+    const { removeImageBackground } = await import('../lib/removeBg');
+    await removeImageBackground('first');
+    const result = await removeImageBackground('second');
+    expect(result).toBe('again');
+    expect(Worker).toHaveBeenCalledTimes(1);
+  });
 });
 

--- a/docs/log/2025-08-25.md
+++ b/docs/log/2025-08-25.md
@@ -52,3 +52,5 @@
 - Introduced lib/metaTags.ts for OG/Twitter tags.
 - Export and toolbar now copy meta tags using util.
 - Added unit tests for meta tag builder and toolbar clipboard.
+- Validated NextAuth environment variables with Zod and removed fallback defaults.
+- Added tests for missing env variables and documented configuration.

--- a/lib/authOptions.ts
+++ b/lib/authOptions.ts
@@ -5,6 +5,21 @@ import LinkedinProvider from 'next-auth/providers/linkedin';
 import TwitterProvider from 'next-auth/providers/twitter';
 import FacebookProvider from 'next-auth/providers/facebook';
 import InstagramProvider from 'next-auth/providers/instagram';
+import {
+  GOOGLE_CLIENT_ID,
+  GOOGLE_CLIENT_SECRET,
+  GITHUB_CLIENT_ID,
+  GITHUB_CLIENT_SECRET,
+  LINKEDIN_CLIENT_ID,
+  LINKEDIN_CLIENT_SECRET,
+  TWITTER_CONSUMER_KEY,
+  TWITTER_CONSUMER_SECRET,
+  FACEBOOK_CLIENT_ID,
+  FACEBOOK_CLIENT_SECRET,
+  INSTAGRAM_CLIENT_ID,
+  INSTAGRAM_CLIENT_SECRET,
+  NEXTAUTH_SECRET,
+} from './env';
 
 
 /**
@@ -16,34 +31,34 @@ export const authOptions: NextAuthOptions = {
   // Configure one or more authentication providers
   providers: [
     GoogleProvider({
-      clientId: process.env.GOOGLE_CLIENT_ID ?? '',
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? '',
+      clientId: GOOGLE_CLIENT_ID,
+      clientSecret: GOOGLE_CLIENT_SECRET,
       authorization: { params: { prompt: "consent", access_type: "offline", response_type: "code" } }
     }),
     GithubProvider({
-      clientId: process.env.GITHUB_CLIENT_ID ?? '',
-      clientSecret: process.env.GITHUB_CLIENT_SECRET ?? '',
+      clientId: GITHUB_CLIENT_ID,
+      clientSecret: GITHUB_CLIENT_SECRET,
     }),
     LinkedinProvider({
-      clientId: process.env.LINKEDIN_CLIENT_ID ?? '',
-      clientSecret: process.env.LINKEDIN_CLIENT_SECRET ?? '',
+      clientId: LINKEDIN_CLIENT_ID,
+      clientSecret: LINKEDIN_CLIENT_SECRET,
       authorization: { params: { scope: "openid profile email" } }
     }),
     TwitterProvider({
-      clientId: process.env.TWITTER_CONSUMER_KEY ?? '',
-      clientSecret: process.env.TWITTER_CONSUMER_SECRET ?? '',
+      clientId: TWITTER_CONSUMER_KEY,
+      clientSecret: TWITTER_CONSUMER_SECRET,
       version: '1.0A'
     }),
     FacebookProvider({
-      clientId: process.env.FACEBOOK_CLIENT_ID ?? '',
-      clientSecret: process.env.FACEBOOK_CLIENT_SECRET ?? ''
+      clientId: FACEBOOK_CLIENT_ID,
+      clientSecret: FACEBOOK_CLIENT_SECRET
     }),
     InstagramProvider({
-      clientId: process.env.INSTAGRAM_CLIENT_ID ?? '',
-      clientSecret: process.env.INSTAGRAM_CLIENT_SECRET ?? ''
+      clientId: INSTAGRAM_CLIENT_ID,
+      clientSecret: INSTAGRAM_CLIENT_SECRET
     })
   ],
-  secret: process.env.NEXTAUTH_SECRET,
+  secret: NEXTAUTH_SECRET,
   session: {
     strategy: 'jwt'
   },

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  GOOGLE_CLIENT_ID: z.string().min(1),
+  GOOGLE_CLIENT_SECRET: z.string().min(1),
+  GITHUB_CLIENT_ID: z.string().min(1),
+  GITHUB_CLIENT_SECRET: z.string().min(1),
+  LINKEDIN_CLIENT_ID: z.string().min(1),
+  LINKEDIN_CLIENT_SECRET: z.string().min(1),
+  TWITTER_CONSUMER_KEY: z.string().min(1),
+  TWITTER_CONSUMER_SECRET: z.string().min(1),
+  FACEBOOK_CLIENT_ID: z.string().min(1),
+  FACEBOOK_CLIENT_SECRET: z.string().min(1),
+  INSTAGRAM_CLIENT_ID: z.string().min(1),
+  INSTAGRAM_CLIENT_SECRET: z.string().min(1),
+  NEXTAUTH_SECRET: z.string().min(1),
+});
+
+const env = envSchema.parse(process.env);
+
+export const {
+  GOOGLE_CLIENT_ID,
+  GOOGLE_CLIENT_SECRET,
+  GITHUB_CLIENT_ID,
+  GITHUB_CLIENT_SECRET,
+  LINKEDIN_CLIENT_ID,
+  LINKEDIN_CLIENT_SECRET,
+  TWITTER_CONSUMER_KEY,
+  TWITTER_CONSUMER_SECRET,
+  FACEBOOK_CLIENT_ID,
+  FACEBOOK_CLIENT_SECRET,
+  INSTAGRAM_CLIENT_ID,
+  INSTAGRAM_CLIENT_SECRET,
+  NEXTAUTH_SECRET,
+} = env;
+
+export type Env = z.infer<typeof envSchema>;
+export default env;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "tailwindcss": "^3.3.5",
+    "zod": "^4.1.1",
     "zustand": "^4.4.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       tailwindcss:
         specifier: ^3.3.5
         version: 3.4.17(ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2))
+      zod:
+        specifier: ^4.1.1
+        version: 4.1.1
       zustand:
         specifier: ^4.4.2
         version: 4.5.7(@types/react@18.3.24)(react@18.3.1)
@@ -3427,6 +3430,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.1.1:
+    resolution: {integrity: sha512-SgMZK/h8Tigt9nnKkfJMvB/mKjiJXaX26xegP4sa+0wHIFVFWVlsQGdhklDmuargBD3Hsi3rsQRIzwJIhTPJHA==}
 
   zustand@4.5.7:
     resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
@@ -7327,6 +7333,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@3.25.76: {}
+
+  zod@4.1.1: {}
 
   zustand@4.5.7(@types/react@18.3.24)(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## Summary
- validate NextAuth env vars with Zod and remove fallbacks
- test auth and worker reuse, document env checks

## Docs Updated
- [x] docs/log/2025-08-25.md
- [ ] docs/dev_doc.md
- [x] README.md

## Tests
- [x] `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac69ec10f4832b86870013c039109e