### PR TITLE
Simplify CanvasStage export container

### DIFF
--- a/__tests__/canvas-stage.test.tsx
+++ b/__tests__/canvas-stage.test.tsx
@@ -13,12 +13,18 @@ describe('CanvasStage', () => {
     });
   });
 
-  it('renders banner image using img tag', () => {
+  it('renders a single banner image using img tag', () => {
     render(<CanvasStage />);
     const banners = screen.getAllByAltText('Banner image') as HTMLImageElement[];
-    expect(banners[0]).toBeInTheDocument();
+    expect(banners).toHaveLength(1);
     expect(banners[0].tagName).toBe('IMG');
     expect(banners[0].getAttribute('src')).toBe('https://example.com/banner.png');
+  });
+
+  it('exports element has fixed base dimensions', () => {
+    render(<CanvasStage />);
+    const canvas = document.getElementById('og-canvas') as HTMLElement;
+    expect(canvas).toHaveStyle({ width: '1200px', height: '630px' });
   });
 
   it('positions the logo at the center by default', () => {

--- a/__tests__/editor-canvas-stage.test.tsx
+++ b/__tests__/editor-canvas-stage.test.tsx
@@ -19,10 +19,10 @@ describe('Editor CanvasStage', () => {
     expect(screen.getByText('Subheading')).toBeInTheDocument();
   });
 
-  it('renders banner image using img tag', () => {
+  it('renders a single banner image using img tag', () => {
     render(<CanvasStage />);
     const banners = screen.getAllByAltText('Banner image') as HTMLImageElement[];
-    expect(banners[0]).toBeInTheDocument();
+    expect(banners).toHaveLength(1);
     expect(banners[0].tagName).toBe('IMG');
     expect(banners[0].getAttribute('src')).toBe('https://example.com/banner.png');
   });

--- a/components/CanvasStage.tsx
+++ b/components/CanvasStage.tsx
@@ -19,7 +19,6 @@ const BASE_HEIGHT = 630;
 export default function CanvasStage() {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [zoom, setZoom] = useState(1);
-  const base = { w: 1200, h: 630 };
   const {
     title,
     subtitle,
@@ -121,29 +120,16 @@ export default function CanvasStage() {
 
   return (
     <div
-      id="og-canvas"
-      className={`relative w-full h-0 pt-[52.5%] overflow-hidden rounded-lg shadow-md border ${themeClasses} focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring`}
-      style={{ borderColor: accentColor }}
+      ref={containerRef}
+      className="relative w-full h-0 pt-[52.5%] overflow-hidden rounded-lg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring"
       tabIndex={0}
       role="img"
       aria-label="OG image preview"
       onKeyDown={handleKeyDown}
     >
-      {/* Banner */}
-      {bannerUrl && (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img
-          src={bannerUrl}
-          alt="Banner image"
-          className="absolute inset-0 w-full h-full object-cover"
-        />
-      )}
-      {/* Overlay to darken/lighten banner for contrast */}
-      {bannerUrl && <div className={`absolute inset-0 ${theme === 'dark' ? 'bg-black/50' : 'bg-white/60'}`} />} 
-      {/* Content container */}
       <div
         id="og-canvas"
-        className={`relative rounded-lg shadow-md border ${themeClasses}`}
+        className={`absolute top-0 left-0 rounded-lg shadow-md border ${themeClasses}`}
         style={{
           width: BASE_WIDTH,
           height: BASE_HEIGHT,
@@ -152,7 +138,6 @@ export default function CanvasStage() {
           borderColor: accentColor
         }}
       >
-        {/* Banner */}
         {bannerUrl && (
           // eslint-disable-next-line @next/next/no-img-element
           <img
@@ -161,13 +146,10 @@ export default function CanvasStage() {
             className="absolute inset-0 w-full h-full object-cover"
           />
         )}
-        {/* Overlay to darken/lighten banner for contrast */}
         {bannerUrl && <div className={`absolute inset-0 ${theme === 'dark' ? 'bg-black/50' : 'bg-white/60'}`} />}
-        {/* Content container */}
         <div
           className={`absolute inset-0 flex flex-col justify-center px-12 py-8 space-y-4 ${layoutClasses}`}
         >
-
           <h1
             className="font-bold leading-tight break-words"
             style={{ color: accentColor, fontSize: `${titleFontSize}px` }}
@@ -178,7 +160,6 @@ export default function CanvasStage() {
             {subtitle}
           </p>
         </div>
-        {/* Logo overlay */}
         {logoDataUrl && (
           <div
             className="absolute"

--- a/docs/log/2025-08-25.md
+++ b/docs/log/2025-08-25.md
@@ -14,6 +14,7 @@
 - Added tests to raise coverage for random style generator and background removal utility.
 - Added meta tag builder util and wired copy-meta actions across controls and toolbar.
 - Escape HTML characters in meta tag fields to prevent injection.
+- Simplified CanvasStage to single export container with fixed dimensions.
 
 ## Changed
 - Added sanitizeSvg and svgToPng helpers.
@@ -31,6 +32,9 @@
 - components/editor/CanvasStage.tsx
 - components/editor/panels/CanvasPanel.tsx
 - README.md
+- components/CanvasStage.tsx
+- __tests__/canvas-stage.test.tsx
+- __tests__/editor-canvas-stage.test.tsx
 - Added bindings for logo inputs and image processing toggles.
 - Connected scale slider and reset/center actions to logo state.
 - Wire TextPanel inputs to editor store with font size controls.


### PR DESCRIPTION
## Summary
- remove duplicate overlay, keeping one `#og-canvas` with fixed 1200x630 size
- adjust ResizeObserver to scale only the wrapper container

## Screenshots/GIF
- N/A

## Docs Updated
- [x] docs/log/2025-08-25.md
- [ ] docs/dev_doc.md
- [ ] README.md

## Tests
- [x] Unit
- [x] Component
- [ ] E2E

## Checklist
- [x] A11y considered
- [ ] Fallbacks & errors handled
- [ ] Env vars documented (if any)


------
https://chatgpt.com/codex/tasks/task_e_68ac6c16c044832bba9a3fcb469b2921