### PR TITLE
feat: toast on meta copy

### DIFF
--- a/components/editor/panels/ExportPanel.tsx
+++ b/components/editor/panels/ExportPanel.tsx
@@ -3,7 +3,8 @@
 import { useState } from "react";
 import { useEditorStore } from "lib/editorStore";
 import { exportElementAsPng, type ImageSize } from "lib/images";
-import { buildMetaTags } from "lib/meta";
+import { copyMetaTags } from "lib/meta";
+import { toast } from "components/ToastProvider";
 
 const SIZE_PRESETS: Record<string, ImageSize> = {
   "1200x630": { width: 1200, height: 630 },
@@ -32,9 +33,14 @@ export default function ExportPanel() {
     }
   };
 
-  const handleCopyMeta = () => {
-    const tags = buildMetaTags({ title, description: subtitle });
-    navigator.clipboard.writeText(tags).catch(console.error);
+  const handleCopyMeta = async () => {
+    try {
+      await copyMetaTags({ title, description: subtitle });
+      toast({ message: "Meta tags copied" });
+    } catch (err) {
+      toast({ message: "Failed to copy meta tags", variant: "error" });
+      console.error(err);
+    }
   };
 
   return (

--- a/docs/log/2025-08-25.md
+++ b/docs/log/2025-08-25.md
@@ -18,6 +18,7 @@
 - Fix export size selection and highlight active preset.
 - Consolidated meta tag builder into `lib/meta.ts` and removed `lib/metaTags.ts`.
 - Removed deprecated EditorControls and ExportControls components in favor of Toolbar and panel workflow.
+- Replaced ExportPanel meta copy logic with shared helper and toast notifications.
 
 ## Changed
 - Added sanitizeSvg and svgToPng helpers.
@@ -65,3 +66,4 @@
 - components/editor/panels/ExportPanel.tsx
 - __tests__/export-panel.test.tsx
 - Removed `lib/metaTags.ts`, updated components and tests to use `lib/meta.ts`.
+- components/editor/panels/ExportPanel.tsx


### PR DESCRIPTION
## Summary
- use `copyMetaTags` helper in export panel and toast on success or failure

## Screenshots/GIF
- n/a

## Docs Updated
- [x] docs/log/2025-08-25.md
- [ ] docs/dev_doc.md
- [ ] README.md

## Tests
- [x] Unit
- [x] Component
- [ ] E2E

## Checklist
- [ ] A11y considered
- [x] Fallbacks & errors handled
- [ ] Env vars documented (if any)


------
https://chatgpt.com/codex/tasks/task_e_68ac73bf0024832ba2decd71fe313fdd