### PR TITLE
feat: surface clipboard errors for meta tags

### DIFF
--- a/__tests__/meta.test.ts
+++ b/__tests__/meta.test.ts
@@ -17,6 +17,12 @@ describe('meta helpers', () => {
     expect(writeText).toHaveBeenCalled();
   });
 
+  it('propagates clipboard errors', async () => {
+    const writeText = jest.fn().mockRejectedValue(new Error('denied'));
+    Object.assign(navigator, { clipboard: { writeText } });
+    await expect(copyMetaTags({ title: 't' })).rejects.toThrow('denied');
+  });
+
   it('adds url tag when url is provided', () => {
     const tags = buildMetaTags({ title: 'T', description: 'D', url: 'https://x.com' });
     expect(tags).toContain('<meta property="og:url" content="https://x.com" />');

--- a/components/editor/Toolbar.tsx
+++ b/components/editor/Toolbar.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect } from "react";
 import { useEditorStore } from "lib/editorStore";
 import { exportElementAsPng } from "lib/images";
-import { buildMetaTags } from "lib/meta";
+import { copyMetaTags } from "lib/meta";
 
 export default function Toolbar() {
   const {
@@ -19,9 +19,13 @@ export default function Toolbar() {
 
   const handleUndo = useCallback(() => undo(), [undo]);
   const handleRedo = useCallback(() => redo(), [redo]);
-  const handleCopyMeta = () => {
-    const tags = buildMetaTags({ title, description: subtitle });
-    navigator.clipboard.writeText(tags).then(() => console.log("copy meta")).catch(console.error);
+  const handleCopyMeta = async () => {
+    try {
+      await copyMetaTags({ title, description: subtitle });
+      console.log("copy meta");
+    } catch (err) {
+      console.error(err);
+    }
   };
   const handleExport = useCallback(async () => {
     const element = document.getElementById("og-canvas");

--- a/components/editor/panels/ExportPanel.tsx
+++ b/components/editor/panels/ExportPanel.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useEditorStore } from "lib/editorStore";
 import { exportElementAsPng, type ImageSize } from "lib/images";
-import { buildMetaTags } from "lib/meta";
+import { copyMetaTags } from "lib/meta";
 
 const SIZE_PRESETS: Record<string, ImageSize> = {
   "1200x630": { width: 1200, height: 630 },
@@ -32,9 +32,12 @@ export default function ExportPanel() {
     }
   };
 
-  const handleCopyMeta = () => {
-    const tags = buildMetaTags({ title, description: subtitle });
-    navigator.clipboard.writeText(tags).catch(console.error);
+  const handleCopyMeta = async () => {
+    try {
+      await copyMetaTags({ title, description: subtitle });
+    } catch (err) {
+      console.error(err);
+    }
   };
 
   return (

--- a/docs/log/2025-08-25.md
+++ b/docs/log/2025-08-25.md
@@ -18,6 +18,7 @@
 - Fix export size selection and highlight active preset.
 - Consolidated meta tag builder into `lib/meta.ts` and removed `lib/metaTags.ts`.
 - Removed deprecated EditorControls and ExportControls components in favor of Toolbar and panel workflow.
+- Propagate clipboard write errors and expose rejections to UI handlers.
 
 ## Changed
 - Added sanitizeSvg and svgToPng helpers.
@@ -65,3 +66,7 @@
 - components/editor/panels/ExportPanel.tsx
 - __tests__/export-panel.test.tsx
 - Removed `lib/metaTags.ts`, updated components and tests to use `lib/meta.ts`.
+- lib/meta.ts
+- components/editor/Toolbar.tsx
+- components/editor/panels/ExportPanel.tsx
+- __tests__/meta.test.ts

--- a/lib/meta.ts
+++ b/lib/meta.ts
@@ -68,6 +68,9 @@ export function buildMetaTags({
 
 export async function copyMetaTags(options: MetaOptions): Promise<void> {
   const tags = buildMetaTags(options);
-  await navigator.clipboard.writeText(tags);
-
+  try {
+    await navigator.clipboard.writeText(tags);
+  } catch (err) {
+    return Promise.reject(err);
+  }
 }


### PR DESCRIPTION
## Summary
- propagate clipboard write errors from `copyMetaTags`
- guard toolbar and export panel copy actions
- test clipboard failure path

## Screenshots/GIF
- N/A

## Docs Updated
- [x] docs/log/2025-08-25.md
- [ ] docs/dev_doc.md
- [ ] README.md

## Tests
- [x] Unit
- [ ] Component
- [ ] E2E

## Checklist
- [ ] A11y considered
- [x] Fallbacks & errors handled
- [ ] Env vars documented (if any)


------
https://chatgpt.com/codex/tasks/task_e_68ac73c15594832b999191a7ea58d707