### PR TITLE
feat: add loading state to auth buttons

### DIFF
--- a/__tests__/auth-buttons.test.tsx
+++ b/__tests__/auth-buttons.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import AuthButtons from '../components/AuthButtons';
+import { useSession } from 'next-auth/react';
+
+jest.mock('next-auth/react', () => ({
+  useSession: jest.fn(),
+  signIn: jest.fn(),
+  signOut: jest.fn(),
+}));
+
+const mockedUseSession = useSession as jest.MockedFunction<typeof useSession>;
+
+describe('AuthButtons', () => {
+  it('renders loading placeholder with aria attributes', () => {
+    mockedUseSession.mockReturnValue({ data: null, status: 'loading' } as any);
+    render(<AuthButtons />);
+    const loadingBtn = screen.getByRole('button', { name: /carregando/i });
+    expect(loadingBtn).toBeDisabled();
+    expect(loadingBtn).toHaveAttribute('aria-busy', 'true');
+  });
+});

--- a/components/AuthButtons.tsx
+++ b/components/AuthButtons.tsx
@@ -11,7 +11,39 @@ export default function AuthButtons() {
   const { data: session, status } = useSession();
 
   if (status === 'loading') {
-    return null;
+    return (
+      <div className="space-x-3">
+        <button
+          type="button"
+          className="flex items-center justify-center rounded-md bg-gray-200 px-4 py-2 text-sm font-medium text-gray-700"
+          disabled
+          aria-busy="true"
+        >
+          <svg
+            className="h-4 w-4 animate-spin"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            ></circle>
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+            ></path>
+          </svg>
+          <span className="sr-only">Carregando</span>
+        </button>
+      </div>
+    );
   }
 
   return (

--- a/docs/log/2025-08-25.md
+++ b/docs/log/2025-08-25.md
@@ -18,6 +18,7 @@
 - Fix export size selection and highlight active preset.
 - Consolidated meta tag builder into `lib/meta.ts` and removed `lib/metaTags.ts`.
 - Removed deprecated EditorControls and ExportControls components in favor of Toolbar and panel workflow.
+- Added loading placeholder to authentication buttons.
 
 ## Changed
 - Added sanitizeSvg and svgToPng helpers.
@@ -65,3 +66,4 @@
 - components/editor/panels/ExportPanel.tsx
 - __tests__/export-panel.test.tsx
 - Removed `lib/metaTags.ts`, updated components and tests to use `lib/meta.ts`.
+- components/AuthButtons.tsx


### PR DESCRIPTION
## Summary
- show accessible loading placeholder while auth status is pending
- document addition in daily log

## Screenshots/GIF
N/A

## Docs Updated
- [x] docs/log/2025-08-25.md
- [ ] docs/dev_doc.md
- [ ] README.md

## Tests
- [ ] Unit
- [x] Component
- [ ] E2E

## Checklist
- [x] A11y considered
- [x] Fallbacks & errors handled
- [ ] Env vars documented (if any)


------
https://chatgpt.com/codex/tasks/task_e_68ac73c5bfb8832b8d558e2dbbd6e97e