### PR TITLE
Fix ESLint warnings in editor and auth modules

### DIFF
--- a/components/CanvasStage.tsx
+++ b/components/CanvasStage.tsx
@@ -24,7 +24,6 @@ export default function CanvasStage() {
     title,
     subtitle,
     titleFontSize,
-    subtitleFontSize,
     theme,
     layout,
     accentColor,

--- a/components/editor/Toolbar.tsx
+++ b/components/editor/Toolbar.tsx
@@ -19,14 +19,13 @@ export default function Toolbar() {
 
   const handleUndo = useCallback(() => undo(), [undo]);
   const handleRedo = useCallback(() => redo(), [redo]);
-  const handleCopyMeta = async () => {
+  const handleCopyMeta = useCallback(async () => {
     try {
       await copyMetaTags({ title, description: subtitle });
-      console.log("copy meta");
     } catch (err) {
       console.error(err);
     }
-  };
+  }, [title, subtitle]);
   const handleExport = useCallback(async () => {
     const element = document.getElementById("og-canvas");
     if (!element) return;

--- a/docs/log/2025-08-27.md
+++ b/docs/log/2025-08-27.md
@@ -1,0 +1,11 @@
+# 2025-08-27
+
+## Summary
+- Resolve ESLint errors and warnings in toolbar, auth, and editor store.
+
+## Changed
+- components/editor/Toolbar.tsx
+- lib/auth.ts
+- lib/editorStore.ts
+- components/CanvasStage.tsx
+- docs/log/2025-08-27.md

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,11 +1,17 @@
 import NextAuth from "next-auth";
+import type { Session } from "next-auth";
+import type { Provider } from "next-auth/providers";
 import Google from "next-auth/providers/google";
 import GitHub from "next-auth/providers/github";
 import Twitter from "next-auth/providers/twitter";
 import Facebook from "next-auth/providers/facebook";
 import { env } from "./env";
 
-export const providers: any[] = [];
+interface ExtendedSession extends Session {
+  userId?: string;
+}
+
+export const providers: Provider[] = [];
 
 if (env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET) {
   providers.push(
@@ -35,8 +41,9 @@ export const { handlers, auth } = NextAuth({
   providers,
   callbacks: {
     async session({ session, token }) {
-      if (token?.sub) (session as any).userId = token.sub;
-      return session;
+      const s = session as ExtendedSession;
+      if (token?.sub) s.userId = token.sub;
+      return s;
     },
   },
 });

--- a/lib/editorStore.ts
+++ b/lib/editorStore.ts
@@ -67,30 +67,41 @@ export const useEditorStore = create<EditorState>()(
       const past: EditorData[] = [];
       const future: EditorData[] = [];
 
-      const stripActions = (state: EditorState): EditorData => {
-        const {
-          setTitle,
-          setSubtitle,
-          setTheme,
-          setLayout,
-          setAccentColor,
-          setBannerUrl,
-          setLogoFile,
-          setLogoUrl,
-          setLogoPosition,
-          setLogoScale,
-          toggleInvertLogo,
-          toggleRemoveLogoBg,
-          toggleMaskLogo,
-          addPreset,
-          applyPreset,
-          undo,
-          redo,
-          reset,
-          ...data
-        } = state;
-        return data;
-      };
+      const stripActions = ({
+        title,
+        subtitle,
+        titleFontSize,
+        subtitleFontSize,
+        theme,
+        layout,
+        accentColor,
+        bannerUrl,
+        logoFile,
+        logoUrl,
+        logoPosition,
+        logoScale,
+        invertLogo,
+        removeLogoBg,
+        maskLogo,
+        presets,
+      }: EditorState): EditorData => ({
+        title,
+        subtitle,
+        titleFontSize,
+        subtitleFontSize,
+        theme,
+        layout,
+        accentColor,
+        bannerUrl,
+        logoFile,
+        logoUrl,
+        logoPosition,
+        logoScale,
+        invertLogo,
+        removeLogoBg,
+        maskLogo,
+        presets,
+      });
 
       const apply = (partial: Partial<EditorData>) =>
         set((state) => {


### PR DESCRIPTION
## Summary
- wrap toolbar meta handler in useCallback
- type NextAuth providers and session without `any`
- simplify editor state action stripping and clean CanvasStage destructure

## Screenshots/GIF
(none)

## Docs Updated
- [x] docs/log/2025-08-27.md
- [ ] docs/dev_doc.md
- [ ] README.md

## Tests
- [ ] Unit
- [ ] Component
- [ ] E2E

## Checklist
- [ ] A11y considered
- [ ] Fallbacks & errors handled
- [ ] Env vars documented (if any)


------
https://chatgpt.com/codex/tasks/task_e_68ac7ea1b344832b8eee486d785eb8b8