### PR TITLE
feat: allow default auth secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ cp .env.example .env.local
 
 Preencha cada chave com valores obtidos nos provedores OAuth (Google, GitHub, etc.) e defina um `NEXTAUTH_SECRET` forte. As credenciais de Twitter, Facebook e Instagram são **opcionais**; se ausentes, os botões de login desses provedores não aparecerão.
 
-As variáveis são validadas em tempo de inicialização pelo arquivo `lib/env.ts` usando [Zod](https://github.com/colinhacks/zod). A aplicação exibirá erro e não iniciará caso alguma variável **obrigatória** esteja ausente ou vazia.
+As variáveis são validadas em tempo de inicialização pelo arquivo `lib/env.ts` usando [Zod](https://github.com/colinhacks/zod). Caso `NEXTAUTH_SECRET` esteja ausente, um valor inseguro `dev-secret` é usado apenas para desenvolvimento; sempre configure um segredo real em produção. A aplicação exibirá erro e não iniciará caso qualquer outra variável **obrigatória** esteja ausente ou vazia.
 
 Exemplo mínimo para desenvolvimento:
 

--- a/__tests__/auth.test.ts
+++ b/__tests__/auth.test.ts
@@ -1,3 +1,13 @@
+jest.mock('next-auth', () => ({
+  __esModule: true,
+  default: jest.fn(() => (() => {})),
+  getServerSession: jest.fn(() => Promise.resolve(null)),
+}));
+jest.mock('next-auth/providers/google', () => ({ __esModule: true, default: () => ({ id: 'google' }) }));
+jest.mock('next-auth/providers/github', () => ({ __esModule: true, default: () => ({ id: 'github' }) }));
+jest.mock('next-auth/providers/twitter', () => ({ __esModule: true, default: () => ({ id: 'twitter' }) }));
+jest.mock('next-auth/providers/facebook', () => ({ __esModule: true, default: () => ({ id: 'facebook' }) }));
+
 describe('auth', () => {
   const originalEnv = process.env;
 
@@ -28,10 +38,11 @@ describe('auth', () => {
     expect(ids).toContain('google');
   });
 
-  it('throws when NEXTAUTH_SECRET is missing', () => {
+  it('uses a fallback secret when NEXTAUTH_SECRET is missing', () => {
     delete (process.env as any).NEXTAUTH_SECRET;
     jest.resetModules();
-    expect(() => require('../lib/auth')).toThrow();
+    const { env } = require('../lib/env');
+    expect(env.NEXTAUTH_SECRET).toBe('dev-secret');
   });
 
   it('session callback returns session unchanged when token lacks sub', async () => {

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -94,7 +94,7 @@ Create `.env.local` with:
 
 ```
 NEXTAUTH_URL=https://your-vercel-domain.vercel.app
-NEXTAUTH_SECRET=... # openssl rand -base64 32
+NEXTAUTH_SECRET=... # openssl rand -base64 32 (fallback dev-secret if unset)
 
 GOOGLE_CLIENT_ID=...
 GOOGLE_CLIENT_SECRET=...

--- a/docs/log/2025-08-28.md
+++ b/docs/log/2025-08-28.md
@@ -1,0 +1,11 @@
+# 2025-08-28
+
+## Summary
+- Allow missing `NEXTAUTH_SECRET` to fall back to a development value so builds don't fail.
+
+## Changed
+- lib/env.ts
+- lib/auth.ts
+- __tests__/auth.test.ts
+- README.md
+- docs/dev_doc.md

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,5 +1,7 @@
 import NextAuth from "next-auth";
+import { getServerSession } from "next-auth";
 import type { Session } from "next-auth";
+import type { JWT } from "next-auth/jwt";
 import type { Provider } from "next-auth/providers";
 import Google from "next-auth/providers/google";
 import GitHub from "next-auth/providers/github";
@@ -37,13 +39,16 @@ if (env.FACEBOOK_CLIENT_ID && env.FACEBOOK_CLIENT_SECRET) {
   );
 }
 
-export const { handlers, auth } = NextAuth({
+export const authOptions = {
   providers,
   callbacks: {
-    async session({ session, token }) {
+    async session({ session, token }: { session: Session; token: JWT }) {
       const s = session as ExtendedSession;
       if (token?.sub) s.userId = token.sub;
       return s;
     },
   },
-});
+};
+
+export const handlers = NextAuth(authOptions);
+export const auth = () => getServerSession(authOptions);

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -3,7 +3,10 @@ import { z } from "zod";
 const clean = (v?: string) => (v?.trim() ? v.trim() : undefined);
 
 const base = z.object({
-  NEXTAUTH_SECRET: z.string().min(1, "NEXTAUTH_SECRET is required"),
+  // Provide a default secret so builds/dev server don't crash when the variable
+  // is missing. Real deployments should always override this with a secure
+  // value via NEXTAUTH_SECRET.
+  NEXTAUTH_SECRET: z.string().min(1).default("dev-secret"),
   NEXTAUTH_URL: z.string().url().optional(),
   GOOGLE_CLIENT_ID: z.string().optional(),
   GOOGLE_CLIENT_SECRET: z.string().optional(),


### PR DESCRIPTION
## Summary
- allow build without NEXTAUTH_SECRET using dev fallback
- mock NextAuth in tests and define auth handlers via getServerSession
- document auth secret fallback

## Docs Updated
- [x] docs/log/2025-08-28.md
- [x] docs/dev_doc.md
- [x] README.md

## Tests
- [ ] Unit *(failed: next/image rewrite causes canvas tests to fail)*
- [ ] Component *(failed: next/image rewrite causes canvas tests to fail)*
- [ ] E2E

------
https://chatgpt.com/codex/tasks/task_e_68ac8202f42c832ba549043f81b38176