### PR TITLE
fix: allow exporting remote images

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ pnpm docs:guard   # garante que docs/log, dev_doc ou README foram atualizados
 ## Problemas Conhecidos
 
 - Alguns sites bloqueiam a coleta de metadados; quando isso ocorre o painel de Metadata exibe um toast de erro.
+- Exportação falhará se o servidor de origem da imagem não permitir CORS, ainda que os elementos usem `crossOrigin="anonymous"`.
 
 ## Licença
 

--- a/__tests__/canvas-stage.test.tsx
+++ b/__tests__/canvas-stage.test.tsx
@@ -34,4 +34,16 @@ describe('CanvasStage', () => {
     const container = logo.parentElement as HTMLElement;
     expect(container).toHaveStyle({ top: '50%', left: '50%' });
   });
+
+  it('marks images as crossOrigin anonymous for export', () => {
+    useEditorStore.setState({
+      bannerUrl: 'https://example.com/banner.png',
+      logoUrl: 'https://example.com/logo.png'
+    });
+    render(<CanvasStage />);
+    const banner = screen.getByAltText('Banner image') as HTMLImageElement;
+    const logo = screen.getByAltText('Logo') as HTMLImageElement;
+    expect(banner.getAttribute('crossorigin')).toBe('anonymous');
+    expect(logo.getAttribute('crossorigin')).toBe('anonymous');
+  });
 });

--- a/__tests__/metadata-panel.test.tsx
+++ b/__tests__/metadata-panel.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import MetadataPanel from '../components/MetadataPanel';
+import MetadataPanel from '../components/editor/panels/MetadataPanel';
 import { useMetadataStore } from '../lib/metadataStore';
 import { toast } from '../components/ToastProvider';
 

--- a/components/CanvasStage.tsx
+++ b/components/CanvasStage.tsx
@@ -137,6 +137,7 @@ export default function CanvasStage() {
             src={bannerUrl}
             alt="Banner image"
             fill
+            crossOrigin="anonymous"
             className="absolute inset-0 w-full h-full object-cover"
           />
         )}
@@ -168,6 +169,7 @@ export default function CanvasStage() {
               alt="Logo"
               width={96}
               height={96}
+              crossOrigin="anonymous"
               className={`object-contain w-24 h-24 ${maskLogo ? 'rounded-full' : ''} shadow`}
             />
           </div>

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -208,6 +208,7 @@ http://localhost:3000/api/auth/callback/<provider>
 
 * PNG @ 2× downscaled; presets 1200×630 (default), 1600×900, 1920×1005.
 * Copy “OG + Twitter meta” block.
+* Canvas images flagged with `crossOrigin="anonymous"`; remote hosts must permit CORS for export.
 
 **Persistence**
 

--- a/docs/log/2025-08-26.md
+++ b/docs/log/2025-08-26.md
@@ -2,8 +2,11 @@
 
 ## Summary
 - Fix broken and flaky tests; adjust coverage threshold.
+- Ensure cross‑origin images export correctly.
 
 ## Changed
 - Rewrote remove background tests.
 - Corrected image utility and export panel tests.
 - Updated Jest coverage settings.
+- Added `crossOrigin="anonymous"` to banner and logo images to avoid tainted canvas during export.
+- Fixed MetadataPanel test import and added cross‑origin assertions for CanvasStage.


### PR DESCRIPTION
## Summary
- mark banner and logo images as crossOrigin="anonymous" to avoid tainted canvas when exporting
- document cross-origin export requirement and test image attributes

## Screenshots/GIF
(none)

## Docs Updated
- [x] docs/log/2025-08-26.md
- [x] docs/dev_doc.md
- [x] README.md

## Tests
- [x] Unit
- [x] Component
- [ ] E2E

## Checklist
- [ ] A11y considered
- [ ] Fallbacks & errors handled
- [ ] Env vars documented (if any)


------
https://chatgpt.com/codex/tasks/task_e_68ad3457d770832bab6fb51d5bac2345