### PR TITLE
feat: improve logo editing and text alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Aplicação Next.js para criar imagens Open Graph personalizadas. Utiliza React,
 ## Recursos
 
 - Editor de logo com upload por arquivo, colagem ou URL
-- Remoção de fundo, inversão B/W e máscara circular do logo
-- Controles de escala e centralização do logo
+- Remoção de fundo, inversão B/W aprimorada e máscara circular do logo
+- Controles de escala, posicionamento e centralização do logo com Undo/Redo
+- Alinhamento de texto horizontal e vertical (esquerda/centro/direita, topo/centro/baixo)
 - Sanitização de campos de metadados
 
 ## Instalação e Uso
@@ -107,7 +108,7 @@ pnpm docs:guard   # garante que docs/log, dev_doc ou README foram atualizados
 
 - Presets automáticos de layout e cores ("Surpreenda‑me")
 - Página de login personalizada
-- Melhorias no editor de logo (inversão de cores)
+- Efeitos adicionais no editor de logo
 - Arrastar e soltar de logo e outras melhorias
 
 - **Desfazer:** Ctrl/Cmd + Z

--- a/__tests__/canvas-stage.test.tsx
+++ b/__tests__/canvas-stage.test.tsx
@@ -35,6 +35,13 @@ describe('CanvasStage', () => {
     expect(container).toHaveStyle({ top: '50%', left: '50%' });
   });
 
+  it('applies vertical alignment classes', () => {
+    useEditorStore.setState({ vertical: 'bottom' });
+    render(<CanvasStage />);
+    const textContainer = document.querySelector('#og-canvas > div.flex') as HTMLElement;
+    expect(textContainer.className).toMatch(/justify-end/);
+  });
+
   it('marks images as crossOrigin anonymous for export', () => {
     useEditorStore.setState({
       bannerUrl: 'https://example.com/banner.png',

--- a/__tests__/images.test.ts
+++ b/__tests__/images.test.ts
@@ -69,6 +69,8 @@ describe('image utilities', () => {
 
     const inverted = await invertImageColors(redPixel);
     expect(inverted.startsWith('data:image/png;base64,')).toBe(true);
+    const putData = (mockCtx.putImageData as jest.Mock).mock.calls[0][0].data as Uint8ClampedArray;
+    expect(Array.from(putData)).toEqual([255, 255, 255, 255]);
   });
 
   it('rejects when canvas context is missing', async () => {

--- a/__tests__/inspector-tabs.test.tsx
+++ b/__tests__/inspector-tabs.test.tsx
@@ -27,6 +27,7 @@ describe('Inspector tabs', () => {
       subtitle: '',
       theme: 'light',
       layout: 'left',
+      vertical: 'center',
       accentColor: '#3b82f6',
       bannerUrl: undefined,
       logoFile: undefined,

--- a/__tests__/logo-panel.test.tsx
+++ b/__tests__/logo-panel.test.tsx
@@ -65,5 +65,15 @@ describe('LogoPanel', () => {
     expect(useEditorStore.getState().logoScale).toBe(1);
     expect(useEditorStore.getState().logoPosition).toEqual({ x: 50, y: 50 });
   });
+
+  it('sets logo position presets and supports undo/redo', () => {
+    render(<LogoPanel />);
+    fireEvent.click(screen.getByText(/top left/i));
+    expect(useEditorStore.getState().logoPosition).toEqual({ x: 10, y: 10 });
+    fireEvent.click(screen.getByText(/undo/i));
+    expect(useEditorStore.getState().logoPosition).toEqual({ x: 10, y: 20 });
+    fireEvent.click(screen.getByText(/redo/i));
+    expect(useEditorStore.getState().logoPosition).toEqual({ x: 10, y: 10 });
+  });
 });
 

--- a/components/CanvasStage.tsx
+++ b/components/CanvasStage.tsx
@@ -30,7 +30,8 @@ export default function CanvasStage() {
     setLogoScale,
     invertLogo,
     removeLogoBg,
-    maskLogo
+    maskLogo,
+    vertical
   } = useEditorStore();
   const [logoDataUrl, setLogoDataUrl] = useState<string | undefined>(undefined);
 
@@ -90,7 +91,18 @@ export default function CanvasStage() {
   }, [logoFile, logoUrl, removeLogoBg, invertLogo]);
 
   const themeClasses = theme === 'dark' ? 'bg-gray-900 text-white' : 'bg-white text-gray-900';
-  const layoutClasses = layout === 'center' ? 'items-center text-center' : 'items-start text-left';
+  const layoutClasses =
+    layout === 'center'
+      ? 'items-center text-center'
+      : layout === 'right'
+        ? 'items-end text-right'
+        : 'items-start text-left';
+  const verticalClasses =
+    vertical === 'top'
+      ? 'justify-start'
+      : vertical === 'bottom'
+        ? 'justify-end'
+        : 'justify-center';
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (
@@ -143,7 +155,7 @@ export default function CanvasStage() {
         )}
         {bannerUrl && <div className={`absolute inset-0 ${theme === 'dark' ? 'bg-black/50' : 'bg-white/60'}`} />}
         <div
-          className={`absolute inset-0 flex flex-col justify-center px-12 py-8 space-y-4 ${layoutClasses}`}
+          className={`absolute inset-0 flex flex-col ${verticalClasses} px-12 py-8 space-y-4 ${layoutClasses}`}
         >
           <h1
             className="font-bold leading-tight break-words"

--- a/components/editor/panels/CanvasPanel.tsx
+++ b/components/editor/panels/CanvasPanel.tsx
@@ -7,6 +7,8 @@ export default function CanvasPanel() {
     setTheme,
     layout,
     setLayout,
+    vertical,
+    setVertical,
     accentColor,
     setAccentColor,
   } = useEditorStore();
@@ -44,15 +46,30 @@ export default function CanvasPanel() {
       </div>
 
       <label className="block">
-        <span className="text-sm">Layout</span>
+        <span className="text-sm">Horizontal</span>
         <select
           className="mt-1 w-full rounded-lg border bg-background px-3 py-2"
           value={layout}
-          onChange={(e) => setLayout(e.target.value as "left" | "center")}
-          aria-label="Layout"
+          onChange={(e) => setLayout(e.target.value as "left" | "center" | "right")}
+          aria-label="Horizontal Alignment"
         >
           <option value="left">Left</option>
           <option value="center">Center</option>
+          <option value="right">Right</option>
+        </select>
+      </label>
+
+      <label className="block">
+        <span className="text-sm">Vertical</span>
+        <select
+          className="mt-1 w-full rounded-lg border bg-background px-3 py-2"
+          value={vertical}
+          onChange={(e) => setVertical(e.target.value as "top" | "center" | "bottom")}
+          aria-label="Vertical Alignment"
+        >
+          <option value="top">Top</option>
+          <option value="center">Center</option>
+          <option value="bottom">Bottom</option>
         </select>
       </label>
 

--- a/components/editor/panels/LogoPanel.tsx
+++ b/components/editor/panels/LogoPanel.tsx
@@ -12,6 +12,8 @@ export default function LogoPanel() {
     logoScale,
     setLogoScale,
     setLogoPosition,
+    undo,
+    redo,
   } = useEditorStore();
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -57,23 +59,28 @@ export default function LogoPanel() {
     setLogoPosition(50, 50);
   };
 
-  const handleCenter = () => {
-    setLogoPosition(50, 50);
-  };
+  const positions = [
+    { label: "Top Left", x: 10, y: 10 },
+    { label: "Top Right", x: 90, y: 10 },
+    { label: "Bottom Left", x: 10, y: 90 },
+    { label: "Bottom Right", x: 90, y: 90 },
+    { label: "Center", x: 50, y: 50 },
+  ];
 
   return (
     <section className="space-y-3">
       <div className="flex items-center gap-2">
-        <label htmlFor="logo-upload" className="sr-only">
-          Upload logo
-        </label>
         <input
           id="logo-upload"
           type="file"
           accept="image/png,image/svg+xml"
           onChange={handleFileChange}
           aria-label="Upload logo file"
+          className="hidden"
         />
+        <label htmlFor="logo-upload" className="btn">
+          Choose File
+        </label>
         <button className="btn" aria-label="Paste logo from clipboard" onClick={handlePaste}>
           Paste
         </button>
@@ -108,14 +115,27 @@ export default function LogoPanel() {
           onChange={(e) => setLogoScale(parseFloat(e.target.value))}
         />
       </div>
-      <div className="grid grid-cols-2 gap-2">
+      <div className="grid grid-cols-3 gap-2">
+        {positions.map((p) => (
+          <button
+            key={p.label}
+            className="btn"
+            aria-label={`Move logo to ${p.label}`}
+            onClick={() => setLogoPosition(p.x, p.y)}
+          >
+            {p.label}
+          </button>
+        ))}
+      </div>
+      <div className="grid grid-cols-3 gap-2">
         <button className="btn" aria-label="Reset logo adjustments" onClick={handleReset}>
           Reset
         </button>
-      </div>
-      <div className="grid grid-cols-2 gap-2">        
-        <button className="btn" onClick={handleCenter} aria-label="Center logo on canvas">
-          Center
+        <button className="btn" aria-label="Undo logo action" onClick={undo}>
+          Undo
+        </button>
+        <button className="btn" aria-label="Redo logo action" onClick={redo}>
+          Redo
         </button>
       </div>
     </section>

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -11,7 +11,7 @@ OGGenerator is a one‑page (expandable) app to **compose Open Graph images** wi
 **MVP Goals**
 
 * Authenticated session via Google and GitHub. Twitter/X and Facebook are optional.
-* Editor with: title, subtitle, theme (light/dark), layout (left/center), background (color/gradient/image), size presets, and **logo editing** (upload via file/paste/URL, translate, scale, remove BG, invert B/W, mask).
+* Editor with: title, subtitle, theme (light/dark), layout (left/center/right, vertical top/center/bottom), background (color/gradient/image), size presets, and **logo editing** (upload via file/paste/URL, translate, scale, remove BG, invert B/W, mask).
 * Export PNG (1200×630 default; extras 1600×900, 1920×1005) and copy meta tags.
 * Basic persistence (local + per‑user cloud).
 
@@ -192,7 +192,7 @@ http://localhost:3000/api/auth/callback/<provider>
 * Base size (1200×630). Zoom to fit viewport, render at 2× for crisp export.
 * Background: solid/gradient/image (with object‑fit cover, position).
 * Text: Title + Subtitle with smart clamp, max width, balance (`text-wrap: balance`).
-* Layout Presets: left/center grid alignment with 8px baseline.
+* Layout Presets: horizontal left/center/right and vertical top/center/bottom alignment with 8px baseline.
 * Logo Layer: PNG/SVG upload (drag‑and‑drop + paste). Controls below.
 
 **Logo Controls**
@@ -202,6 +202,7 @@ http://localhost:3000/api/auth/callback/<provider>
 * **Remove Background**: client‑side WASM U^2‑Net; fallback API route.
 * **Invert B/W**: canvas filter (luminance threshold + invert) — preview toggle.
 * **Mask (Circle)**: optional clipPath for avatars.
+* **Position Presets & Undo/Redo**: quick corner/center placement plus history controls.
 * **Reset**: revert layer transforms.
 
 **Export**
@@ -232,7 +233,8 @@ export type Design = {
   title: string;
   subtitle: string;
   theme: "light" | "dark";
-  layout: "left" | "center";
+  layout: "left" | "center" | "right";
+  vertical: "top" | "center" | "bottom";
   bg: { kind: "solid"|"gradient"|"image"; value: any };
   size: { w: number; h: number };
   logo?: {
@@ -377,7 +379,7 @@ pnpm dev
 ## 14) Definition of Done (MVP)
 
 * User can sign in with at least **2 providers** (Google + GitHub).
-* Editor supports title, subtitle, background, layout, logo translate/scale, remove BG, invert B/W.
+* Editor supports title, subtitle, background, layout & vertical alignment, logo translate/scale, remove BG, invert B/W.
 * PNG export works for 1200×630; other sizes optional.
 * Meta block copies to clipboard.
 * State persists locally and user can save/load at least one **Design** in cloud.

--- a/docs/log/2025-08-26.md
+++ b/docs/log/2025-08-26.md
@@ -3,6 +3,7 @@
 ## Summary
 - Fix broken and flaky tests; adjust coverage threshold.
 - Ensure cross‑origin images export correctly.
+- Improve logo editing and text alignment.
 
 ## Changed
 - Rewrote remove background tests.
@@ -10,3 +11,6 @@
 - Updated Jest coverage settings.
 - Added `crossOrigin="anonymous"` to banner and logo images to avoid tainted canvas during export.
 - Fixed MetadataPanel test import and added cross‑origin assertions for CanvasStage.
+- Added text vertical alignment controls and right alignment option.
+- Introduced logo position presets with Undo/Redo and aligned file/url buttons.
+- Improved invert B/W to use luminance threshold.

--- a/lib/editorStore.ts
+++ b/lib/editorStore.ts
@@ -9,7 +9,8 @@ interface EditorData {
   titleFontSize: number;
   subtitleFontSize: number;
   theme: 'light' | 'dark';
-  layout: 'left' | 'center';
+  layout: 'left' | 'center' | 'right';
+  vertical: 'top' | 'center' | 'bottom';
   accentColor: string;
   bannerUrl?: string;
   logoFile?: File;
@@ -28,7 +29,8 @@ export interface EditorState extends EditorData {
   setTitleFontSize: (size: number) => void;
   setSubtitleFontSize: (size: number) => void;
   setTheme: (value: 'light' | 'dark') => void;
-  setLayout: (value: 'left' | 'center') => void;
+  setLayout: (value: 'left' | 'center' | 'right') => void;
+  setVertical: (value: 'top' | 'center' | 'bottom') => void;
   setAccentColor: (value: string) => void;
   setBannerUrl: (value: string | undefined) => void;
   setLogoFile: (file: File | undefined) => void;
@@ -52,6 +54,7 @@ const initialState: EditorData = {
   subtitleFontSize: 24,
   theme: 'light',
   layout: 'left',
+  vertical: 'center',
   accentColor: '#3b82f6',
   logoPosition: { x: 50, y: 50 },
   logoScale: 1,
@@ -74,6 +77,7 @@ export const useEditorStore = create<EditorState>()(
         subtitleFontSize,
         theme,
         layout,
+        vertical,
         accentColor,
         bannerUrl,
         logoFile,
@@ -91,6 +95,7 @@ export const useEditorStore = create<EditorState>()(
         subtitleFontSize,
         theme,
         layout,
+        vertical,
         accentColor,
         bannerUrl,
         logoFile,
@@ -118,6 +123,7 @@ export const useEditorStore = create<EditorState>()(
         setSubtitleFontSize: (size) => apply({ subtitleFontSize: size }),
         setTheme: (value) => apply({ theme: value }),
         setLayout: (value) => apply({ layout: value }),
+        setVertical: (value) => apply({ vertical: value }),
         setAccentColor: (value) => apply({ accentColor: value }),
         setBannerUrl: (value) => apply({ bannerUrl: value }),
         setLogoFile: (file) => apply({ logoFile: file, logoUrl: undefined }),
@@ -163,6 +169,7 @@ export const useEditorStore = create<EditorState>()(
         subtitle: state.subtitle,
         theme: state.theme,
         layout: state.layout,
+        vertical: state.vertical,
         accentColor: state.accentColor,
         bannerUrl: state.bannerUrl,
         logoUrl: state.logoUrl,

--- a/lib/images.ts
+++ b/lib/images.ts
@@ -83,9 +83,12 @@ export async function invertImageColors(dataUrl: string): Promise<string> {
       const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
       const data = imageData.data;
       for (let i = 0; i < data.length; i += 4) {
-        data[i] = 255 - data[i];
-        data[i + 1] = 255 - data[i + 1];
-        data[i + 2] = 255 - data[i + 2];
+        const r = data[i];
+        const g = data[i + 1];
+        const b = data[i + 2];
+        const luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+        const value = luminance > 128 ? 0 : 255;
+        data[i] = data[i + 1] = data[i + 2] = value;
       }
       ctx.putImageData(imageData, 0, 0);
       resolve(canvas.toDataURL());

--- a/lib/randomStyle.ts
+++ b/lib/randomStyle.ts
@@ -1,6 +1,6 @@
 export interface RandomStyle {
   theme: 'light' | 'dark';
-  layout: 'left' | 'center';
+  layout: 'left' | 'center' | 'right';
   accentColor: string;
 }
 
@@ -9,7 +9,7 @@ export interface RandomStyle {
 export type Preset = RandomStyle;
 
 const themes: RandomStyle['theme'][] = ['light', 'dark'];
-const layouts: RandomStyle['layout'][] = ['left', 'center'];
+const layouts: RandomStyle['layout'][] = ['left', 'center', 'right'];
 // A handful of pleasant accent colors
 const colors: string[] = [
   '#3b82f6', // blue


### PR DESCRIPTION
## Summary
- add logo position presets with undo/redo and aligned file/url buttons
- support right and vertical text alignment; enhance B/W inversion

## Screenshots/GIF

## Docs Updated
- [x] docs/log/2025-08-26.md
- [x] docs/dev_doc.md
- [x] README.md

## Tests
- [x] Unit
- [x] Component
- [ ] E2E

## Checklist
- [x] A11y considered
- [ ] Fallbacks & errors handled
- [ ] Env vars documented (if any)


------
https://chatgpt.com/codex/tasks/task_e_68ad3930c410832b865dd2100eaa014b