### PR TITLE
fix: allow exporting remote images

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Aplicação Next.js para criar imagens Open Graph personalizadas. Utiliza React,
 - Remoção de fundo, inversão B/W e máscara circular do logo
 - Controles de escala e centralização do logo
 - Sanitização de campos de metadados
+- Exportação de PNG em múltiplos tamanhos sem cortes, inclusive com imagens remotas
 
 ## Instalação e Uso
 
@@ -117,6 +118,7 @@ pnpm docs:guard   # garante que docs/log, dev_doc ou README foram atualizados
 ## Problemas Conhecidos
 
 - Alguns sites bloqueiam a coleta de metadados; quando isso ocorre o painel de Metadata exibe um toast de erro.
+- Exportação falhará se o servidor de origem da imagem não permitir CORS, ainda que os elementos usem `crossOrigin="anonymous"`.
 
 ## Licença
 

--- a/__tests__/canvas-stage.test.tsx
+++ b/__tests__/canvas-stage.test.tsx
@@ -34,4 +34,16 @@ describe('CanvasStage', () => {
     const container = logo.parentElement as HTMLElement;
     expect(container).toHaveStyle({ top: '50%', left: '50%' });
   });
+
+  it('marks images as crossOrigin anonymous for export', () => {
+    useEditorStore.setState({
+      bannerUrl: 'https://example.com/banner.png',
+      logoUrl: 'https://example.com/logo.png'
+    });
+    render(<CanvasStage />);
+    const banner = screen.getByAltText('Banner image') as HTMLImageElement;
+    const logo = screen.getByAltText('Logo') as HTMLImageElement;
+    expect(banner.getAttribute('crossorigin')).toBe('anonymous');
+    expect(logo.getAttribute('crossorigin')).toBe('anonymous');
+  });
 });

--- a/__tests__/images.test.ts
+++ b/__tests__/images.test.ts
@@ -152,31 +152,57 @@ describe('image utilities', () => {
     expect(blob.type).toBe('image/png');
   });
 
-  it('waits for fonts and respects pixelRatio when exporting', async () => {
-    const element = document.createElement('div');
-    element.getBoundingClientRect = () => ({ width: 100, height: 50 } as any);
+    it('waits for fonts and respects pixelRatio when exporting', async () => {
+      const element = document.createElement('div');
+      Object.defineProperty(element, 'clientWidth', { value: 100 });
+      Object.defineProperty(element, 'clientHeight', { value: 50 });
 
-    let resolveFonts: () => void;
-    // @ts-ignore
-    document.fonts = { ready: new Promise<void>((r) => (resolveFonts = r)) };
+      let resolveFonts: () => void;
+      // @ts-ignore
+      document.fonts = { ready: new Promise<void>((r) => (resolveFonts = r)) };
 
-    const exportPromise = exportElementAsPng(
-      element,
-      { width: 200, height: 100 },
-      'test.png',
-      { pixelRatio: 2 }
-    );
+      const exportPromise = exportElementAsPng(
+        element,
+        { width: 200, height: 100 },
+        'test.png',
+        { pixelRatio: 2 }
+      );
 
-    const toPngMock = htmlToImage.toPng as jest.Mock;
-    expect(toPngMock).not.toHaveBeenCalled();
+      const toPngMock = htmlToImage.toPng as jest.Mock;
+      expect(toPngMock).not.toHaveBeenCalled();
 
-    resolveFonts();
-    await exportPromise;
+      resolveFonts();
+      await exportPromise;
 
-    expect(toPngMock).toHaveBeenCalledWith(
-      element,
-      expect.objectContaining({ pixelRatio: 2 })
-    );
-  });
+      expect(toPngMock).toHaveBeenCalledWith(
+        element,
+        expect.objectContaining({ pixelRatio: 2 })
+      );
+    });
+
+    it('ignores bounding box transforms when scaling for export', async () => {
+      const element = document.createElement('div');
+      Object.defineProperty(element, 'clientWidth', { value: 100 });
+      Object.defineProperty(element, 'clientHeight', { value: 50 });
+      element.getBoundingClientRect = () => ({ width: 50, height: 25 } as any);
+      // @ts-ignore
+      document.fonts = { ready: Promise.resolve() };
+
+      await exportElementAsPng(element, { width: 200, height: 100 }, 'test.png');
+
+      const toPngMock = htmlToImage.toPng as jest.Mock;
+      expect(toPngMock).toHaveBeenCalledWith(
+        element,
+        expect.objectContaining({
+          width: 200,
+          height: 100,
+          style: expect.objectContaining({
+            transform: 'scale(2, 2)',
+            width: '100px',
+            height: '50px',
+          }),
+        })
+      );
+    });
 });
 

--- a/__tests__/metadata-panel.test.tsx
+++ b/__tests__/metadata-panel.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import MetadataPanel from '../components/MetadataPanel';
+import MetadataPanel from '../components/editor/panels/MetadataPanel';
 import { useMetadataStore } from '../lib/metadataStore';
 import { toast } from '../components/ToastProvider';
 

--- a/components/CanvasStage.tsx
+++ b/components/CanvasStage.tsx
@@ -137,6 +137,7 @@ export default function CanvasStage() {
             src={bannerUrl}
             alt="Banner image"
             fill
+            crossOrigin="anonymous"
             className="absolute inset-0 w-full h-full object-cover"
           />
         )}
@@ -168,6 +169,7 @@ export default function CanvasStage() {
               alt="Logo"
               width={96}
               height={96}
+              crossOrigin="anonymous"
               className={`object-contain w-24 h-24 ${maskLogo ? 'rounded-full' : ''} shadow`}
             />
           </div>

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -208,6 +208,7 @@ http://localhost:3000/api/auth/callback/<provider>
 
 * PNG @ 2× downscaled; presets 1200×630 (default), 1600×900, 1920×1005.
 * Copy “OG + Twitter meta” block.
+* Canvas images flagged with `crossOrigin="anonymous"`; remote hosts must permit CORS for export.
 
 **Persistence**
 
@@ -416,6 +417,7 @@ pnpm build
 
 * **OAuth callback error**: ensure provider console has the exact redirect URL.
 * **Fonts not applied in export**: the export utility awaits `document.fonts.ready`, but ensure custom fonts are loaded.
+* **Exported image cropped**: export uses `clientWidth`/`clientHeight` to ignore preview zoom. Verify these reflect the expected base size.
 * **WASM background removal slow**: run in Worker and lazy‑load the model (\~5–15MB). Cache after first run.
 * **SVG injection risk**: sanitize or rasterize into canvas before any edit.
 

--- a/docs/log/2025-08-26.md
+++ b/docs/log/2025-08-26.md
@@ -2,8 +2,12 @@
 
 ## Summary
 - Fix broken and flaky tests; adjust coverage threshold.
+- Ensure cross‑origin images export correctly.
 
 ## Changed
 - Rewrote remove background tests.
 - Corrected image utility and export panel tests.
 - Updated Jest coverage settings.
+- Added `crossOrigin="anonymous"` to banner and logo images to avoid tainted canvas during export.
+- Fixed MetadataPanel test import and added cross‑origin assertions for CanvasStage.
+- Export scaling now derives from client dimensions to avoid cropped renders.

--- a/lib/images.ts
+++ b/lib/images.ts
@@ -24,8 +24,9 @@ export async function exportElementAsPng(
 ): Promise<void> {
   await document.fonts.ready;
 
-  const { width: originalWidth, height: originalHeight } =
-    element.getBoundingClientRect();
+  // Use client dimensions so preview zoom transforms do not affect export.
+  const originalWidth = element.clientWidth;
+  const originalHeight = element.clientHeight;
 
   const scaleX = size.width / originalWidth;
   const scaleY = size.height / originalHeight;


### PR DESCRIPTION
## Summary
- mark banner and logo images as crossOrigin="anonymous" to avoid tainted canvas when exporting
- derive export size from client dimensions so remote images render without cropping
- document cross-origin and scaling requirements

## Screenshots/GIF
(none)

## Docs Updated
- [x] docs/log/2025-08-26.md
- [x] docs/dev_doc.md
- [x] README.md

## Tests
- [x] Unit
- [x] Component
- [ ] E2E

## Checklist
- [ ] A11y considered
- [ ] Fallbacks & errors handled
- [ ] Env vars documented (if any)


------
https://chatgpt.com/codex/tasks/task_e_68ad3457d770832bab6fb51d5bac2345