### PR TITLE
feat: add draggable logo to canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Aplicação Next.js para criar imagens Open Graph personalizadas. Utiliza React,
 - Editor de logo com upload por arquivo, colagem ou URL
 - Remoção de fundo, inversão B/W aprimorada e máscara circular do logo
 - Controles de escala, posicionamento e centralização do logo com Undo/Redo
+- Arraste o logo diretamente no canvas
 - Alinhamento de texto horizontal e vertical (esquerda/centro/direita, topo/centro/baixo)
 - Sanitização de campos de metadados
 - Exportação de PNG em múltiplos tamanhos sem cortes, inclusive com imagens remotas
@@ -110,7 +111,6 @@ pnpm docs:guard   # garante que docs/log, dev_doc ou README foram atualizados
 - Presets automáticos de layout e cores ("Surpreenda‑me")
 - Página de login personalizada
 - Efeitos adicionais no editor de logo
-- Arrastar e soltar de logo e outras melhorias
 
 - **Desfazer:** Ctrl/Cmd + Z
 - **Refazer:** Ctrl/Cmd + Shift + Z

--- a/__tests__/canvas-drag.test.tsx
+++ b/__tests__/canvas-drag.test.tsx
@@ -1,0 +1,31 @@
+import { render, fireEvent, screen } from '@testing-library/react';
+import CanvasStage from '../components/CanvasStage';
+import { useEditorStore } from '../lib/editorStore';
+
+describe('CanvasStage drag', () => {
+  beforeAll(() => {
+    // jsdom lacks PointerEvent; map to MouseEvent for tests
+    (window as any).PointerEvent = MouseEvent;
+  });
+  beforeEach(() => {
+    useEditorStore.setState({
+      logoUrl: 'https://example.com/logo.png',
+      logoPosition: { x: 50, y: 50 },
+      logoScale: 1,
+    });
+  });
+
+  it('updates store when logo is dragged', () => {
+    render(<CanvasStage />);
+    const logo = screen.getByAltText('Logo');
+    const wrapper = logo.parentElement as HTMLElement;
+
+    fireEvent.pointerDown(wrapper, { clientX: 100, clientY: 100 });
+    fireEvent.pointerMove(wrapper, { clientX: 160, clientY: 130 });
+    fireEvent.pointerUp(wrapper, { clientX: 160, clientY: 130 });
+
+    const { logoPosition } = useEditorStore.getState();
+    expect(logoPosition.x).toBeGreaterThan(50);
+    expect(logoPosition.y).toBeGreaterThan(50);
+  });
+});

--- a/components/CanvasStage.tsx
+++ b/components/CanvasStage.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import Image from 'next/image';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { useEditorStore } from 'lib/editorStore';
 import { invertImageColors, blobToDataURL } from 'lib/images';
 import { removeImageBackground } from 'lib/removeBg';
@@ -124,6 +124,71 @@ export default function CanvasStage() {
     }
   };
 
+  function Draggable({
+    position,
+    onChange,
+    scale = 1,
+    children,
+  }: {
+    position: { x: number; y: number };
+    onChange: (x: number, y: number) => void;
+    scale?: number;
+    children: ReactNode;
+  }) {
+    const [start, setStart] = useState<
+      | {
+          pointer: { x: number; y: number };
+          origin: { x: number; y: number };
+        }
+      | null
+    >(null);
+
+    const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      setStart({
+        pointer: { x: e.clientX, y: e.clientY },
+        origin: { x: position.x, y: position.y },
+      });
+      (e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId);
+    };
+
+    const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!start) return;
+      const dx = e.clientX - start.pointer.x;
+      const dy = e.clientY - start.pointer.y;
+      const x = Math.min(
+        100,
+        Math.max(0, start.origin.x + (dx / (BASE_WIDTH * zoom)) * 100),
+      );
+      const y = Math.min(
+        100,
+        Math.max(0, start.origin.y + (dy / (BASE_HEIGHT * zoom)) * 100),
+      );
+      onChange(x, y);
+    };
+
+    const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+      setStart(null);
+      (e.currentTarget as HTMLElement).releasePointerCapture?.(e.pointerId);
+    };
+
+    return (
+      <div
+        className={`absolute ${start ? 'outline outline-2 outline-blue-500' : ''}`}
+        style={{
+          top: `${position.y}%`,
+          left: `${position.x}%`,
+          transform: `translate(-50%, -50%) scale(${scale})`,
+        }}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+      >
+        {children}
+      </div>
+    );
+  }
+
   return (
     <div
       ref={containerRef}
@@ -168,13 +233,10 @@ export default function CanvasStage() {
           </p>
         </div>
         {logoDataUrl && (
-          <div
-            className="absolute"
-            style={{
-              top: `${logoPosition.y}%`,
-              left: `${logoPosition.x}%`,
-              transform: `translate(-50%, -50%) scale(${logoScale})`
-            }}
+          <Draggable
+            position={logoPosition}
+            onChange={setLogoPosition}
+            scale={logoScale}
           >
             <Image
               src={logoDataUrl}
@@ -184,7 +246,7 @@ export default function CanvasStage() {
               crossOrigin="anonymous"
               className={`object-contain w-24 h-24 ${maskLogo ? 'rounded-full' : ''} shadow`}
             />
-          </div>
+          </Draggable>
         )}
       </div>
     </div>

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -351,7 +351,7 @@ pnpm dev
 ### Sprint 3 — Logo Tools (2–3 days)
 
 * [ ] Upload: file input, paste and URL handled; drag‑and‑drop pending.
-* [ ] Translate + scale + mask (circle) — scale slider and mask toggle done; drag translate pending.
+* [x] Translate + scale + mask (circle) — drag to translate logo and arrow keys for fine-tuning.
 * [x] **Remove Background** via WASM in WebWorker (toggle integrated with helper).
 * [x] **Invert B/W** filter + toggle.
 

--- a/docs/log/2025-08-26.md
+++ b/docs/log/2025-08-26.md
@@ -4,6 +4,7 @@
 - Fix broken and flaky tests; adjust coverage threshold.
 - Ensure cross‑origin images export correctly.
 - Improve logo editing and text alignment.
+- Allow dragging the logo inside the canvas.
 
 ## Changed
 - Rewrote remove background tests.
@@ -15,3 +16,4 @@
 - Added text vertical alignment controls and right alignment option.
 - Introduced logo position presets with Undo/Redo and aligned file/url buttons.
 - Improved invert B/W to use luminance threshold.
+- Wrapped CanvasStage logo in draggable component with pointer events and added drag test.


### PR DESCRIPTION
## Summary
- enable logo dragging within the canvas via pointer events
- document new drag feature and add component test

## Screenshots/GIF
(none)

## Docs Updated
- [x] docs/log/2025-08-26.md
- [x] docs/dev_doc.md
- [x] README.md

## Tests
- [ ] Unit
- [x] Component
- [ ] E2E

## Checklist
- [ ] A11y considered
- [ ] Fallbacks & errors handled
- [ ] Env vars documented (if any)


------
https://chatgpt.com/codex/tasks/task_e_68ad3dfd0d24832ba5d3e7b5ed5d34e7