### PR TITLE
Clamp draggable elements to prevent edge clipping

### DIFF
--- a/__tests__/canvas-drag.test.tsx
+++ b/__tests__/canvas-drag.test.tsx
@@ -16,21 +16,49 @@ describe('CanvasStage drag', () => {
     });
   });
 
-    it('updates store as logo is dragged multiple times', () => {
-      render(<CanvasStage />);
-      const logo = screen.getByAltText('Logo');
-      const wrapper = logo.parentElement as HTMLElement;
+  it('updates store as logo is dragged multiple times', () => {
+    render(<CanvasStage />);
+    const logo = screen.getByAltText('Logo');
+    const wrapper = logo.parentElement as HTMLElement;
 
-      fireEvent.pointerDown(wrapper, { clientX: 100, clientY: 100 });
-      fireEvent.pointerMove(wrapper, { clientX: 160, clientY: 130 });
-      const first = useEditorStore.getState().logoPosition;
-      fireEvent.pointerMove(wrapper, { clientX: 200, clientY: 160 });
-      const second = useEditorStore.getState().logoPosition;
-      fireEvent.pointerUp(wrapper, { clientX: 200, clientY: 160 });
+    fireEvent.pointerDown(wrapper, { clientX: 100, clientY: 100 });
+    fireEvent.pointerMove(wrapper, { clientX: 160, clientY: 130 });
+    const first = useEditorStore.getState().logoPosition;
+    fireEvent.pointerMove(wrapper, { clientX: 200, clientY: 160 });
+    const second = useEditorStore.getState().logoPosition;
+    fireEvent.pointerUp(wrapper, { clientX: 200, clientY: 160 });
 
-      expect(first.x).toBeGreaterThan(50);
-      expect(first.y).toBeGreaterThan(50);
-      expect(second.x).toBeGreaterThan(first.x);
-      expect(second.y).toBeGreaterThan(first.y);
+    expect(first.x).toBeGreaterThan(50);
+    expect(first.y).toBeGreaterThan(50);
+    expect(second.x).toBeGreaterThan(first.x);
+    expect(second.y).toBeGreaterThan(first.y);
+  });
+
+  it('clamps drag to keep the logo fully visible', () => {
+    render(<CanvasStage />);
+    const logo = screen.getByAltText('Logo');
+    const wrapper = logo.parentElement as HTMLElement;
+    Object.defineProperty(wrapper, 'getBoundingClientRect', {
+      value: () => ({
+        width: 96,
+        height: 96,
+        top: 0,
+        left: 0,
+        bottom: 96,
+        right: 96,
+        toJSON: () => {},
+      }),
     });
+
+    fireEvent.pointerDown(wrapper, { clientX: 50, clientY: 50 });
+    fireEvent.pointerMove(wrapper, { clientX: -1000, clientY: -1000 });
+    let pos = useEditorStore.getState().logoPosition;
+    expect(pos.x).toBeCloseTo(4, 1);
+    expect(pos.y).toBeCloseTo(7.6, 1);
+    fireEvent.pointerMove(wrapper, { clientX: 2000, clientY: 2000 });
+    pos = useEditorStore.getState().logoPosition;
+    expect(pos.x).toBeCloseTo(96, 1);
+    expect(pos.y).toBeCloseTo(92.4, 1);
+    fireEvent.pointerUp(wrapper, { clientX: 2000, clientY: 2000 });
+  });
 });

--- a/components/CanvasStage.tsx
+++ b/components/CanvasStage.tsx
@@ -47,14 +47,13 @@ function Draggable({
     if (!start) return;
     const dx = e.clientX - start.pointer.x;
     const dy = e.clientY - start.pointer.y;
-    const x = Math.min(
-      100,
-      Math.max(0, start.origin.x + (dx / (BASE_WIDTH * zoom)) * 100),
-    );
-    const y = Math.min(
-      100,
-      Math.max(0, start.origin.y + (dy / (BASE_HEIGHT * zoom)) * 100),
-    );
+    const rect = e.currentTarget.getBoundingClientRect();
+    const halfWidthPct = (rect.width / (BASE_WIDTH * zoom)) * 50;
+    const halfHeightPct = (rect.height / (BASE_HEIGHT * zoom)) * 50;
+    const nx = start.origin.x + (dx / (BASE_WIDTH * zoom)) * 100;
+    const ny = start.origin.y + (dy / (BASE_HEIGHT * zoom)) * 100;
+    const x = Math.min(100 - halfWidthPct, Math.max(halfWidthPct, nx));
+    const y = Math.min(100 - halfHeightPct, Math.max(halfHeightPct, ny));
     onChange(x, y);
   };
 
@@ -218,6 +217,7 @@ export default function CanvasStage() {
             src={bannerSrc}
             alt="Banner image"
             fill
+            crossOrigin="anonymous"
             className="absolute inset-0 w-full h-full object-cover"
             //unoptimized // avoid double-optimization since we already proxy
           />

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -421,6 +421,7 @@ pnpm build
 * **OAuth callback error**: ensure provider console has the exact redirect URL.
 * **Fonts not applied in export**: the export utility awaits `document.fonts.ready`, but ensure custom fonts are loaded.
 * **Exported image cropped**: export uses `clientWidth`/`clientHeight` to ignore preview zoom. Verify these reflect the expected base size.
+* **Dragged element clipped**: drag limits now subtract half the element size to keep content fully visible.
 * **WASM background removal slow**: run in Worker and lazy‑load the model (\~5–15MB). Cache after first run.
 * **SVG injection risk**: sanitize or rasterize into canvas before any edit.
 

--- a/docs/log/2025-08-26.md
+++ b/docs/log/2025-08-26.md
@@ -23,4 +23,5 @@
 - Wrapped CanvasStage logo in draggable component with pointer events and added drag test.
 - Added numeric X/Y inputs to LogoPanel that mirror drag movements.
 - Hoisted draggable component to preserve state and allow continuous logo dragging.
+- Clamped draggable elements using their dimensions to prevent edge clipping.
 


### PR DESCRIPTION
## Summary
- clamp drag positions using element dimensions to keep items fully inside canvas
- test dragging clamps and log documentation updates

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm docs:guard`
- `pnpm typecheck` *(fails: Command "typecheck" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6ae645cc832b84105ae0c14a350d