### PR TITLE
feat: deform draggable elements near canvas edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Aplicação Next.js para criar imagens Open Graph personalizadas. Utiliza React,
 
 - Editor de logo com upload por arquivo, colagem ou URL
 - Remoção de fundo, inversão B/W aprimorada e máscara circular do logo
-- Arraste o logo diretamente no canvas com limites que evitam recortes nas bordas
+- Arraste o logo diretamente no canvas; ele se deforma quando se aproxima das bordas para evitar recortes
 - Controles de escala e posicionamento do logo com sliders X/Y
 - Posicionamento livre de título e subtítulo arrastando-os no canvas
 - Sanitização de campos de metadados

--- a/__tests__/canvas-drag.test.tsx
+++ b/__tests__/canvas-drag.test.tsx
@@ -1,6 +1,7 @@
 import { render, fireEvent, screen } from '@testing-library/react';
 import CanvasStage from '../components/CanvasStage';
 import { useEditorStore } from '../lib/editorStore';
+import { waitFor } from '@testing-library/react';
 
 describe('CanvasStage drag', () => {
   beforeAll(() => {
@@ -48,8 +49,34 @@ describe('CanvasStage drag', () => {
     expect(pos.y).toBeCloseTo(7.6, 1);
     fireEvent.pointerMove(wrapper, { clientX: 2000, clientY: 2000 });
     pos = useEditorStore.getState().logoPosition;
-    expect(pos.x).toBeCloseTo(96, 1);
-    expect(pos.y).toBeCloseTo(92.4, 1);
+    expect(pos.x).toBeCloseTo(99.2, 1);
+    expect(pos.y).toBeCloseTo(98.48, 1);
     fireEvent.pointerUp(wrapper, { clientX: 2000, clientY: 2000 });
+  });
+
+  const getScale = (el: HTMLElement) => {
+    const match = el.style.transform.match(/scale\(([^)]+)\)/);
+    return match ? parseFloat(match[1]) : 1;
+  };
+
+  it('deforms near edges and restores after release', async () => {
+    render(<CanvasStage />);
+    const logo = screen.getByAltText('Logo');
+    const wrapper = logo.parentElement as HTMLElement;
+    Object.defineProperty(wrapper, 'offsetWidth', { value: 96 });
+    Object.defineProperty(wrapper, 'offsetHeight', { value: 96 });
+
+    fireEvent.pointerDown(wrapper, { clientX: 50, clientY: 50 });
+    fireEvent.pointerMove(wrapper, { clientX: -1000, clientY: 50 });
+
+    await waitFor(() => {
+      expect(getScale(wrapper)).toBeLessThan(1);
+    });
+
+    fireEvent.pointerUp(wrapper, { clientX: -1000, clientY: 50 });
+
+    await waitFor(() => {
+      expect(getScale(wrapper)).toBeCloseTo(1);
+    });
   });
 });

--- a/components/CanvasStage.tsx
+++ b/components/CanvasStage.tsx
@@ -33,6 +33,8 @@ function Draggable({
     }
     | null
   >(null);
+  const [deform, setDeform] = useState(1);
+  const DEFORM_THRESHOLD = 5;
 
   const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     e.preventDefault();
@@ -48,19 +50,33 @@ function Draggable({
     const dx = e.clientX - start.pointer.x;
     const dy = e.clientY - start.pointer.y;
     const el = e.currentTarget as HTMLElement;
-    const width = el.offsetWidth * scale;
-    const height = el.offsetHeight * scale;
+    const currentScale = scale * deform;
+    const width = el.offsetWidth * currentScale;
+    const height = el.offsetHeight * currentScale;
     const halfWidthPct = (width / BASE_WIDTH) * 50;
     const halfHeightPct = (height / BASE_HEIGHT) * 50;
     const nx = start.origin.x + (dx / (BASE_WIDTH * zoom)) * 100;
     const ny = start.origin.y + (dy / (BASE_HEIGHT * zoom)) * 100;
     const x = Math.min(100 - halfWidthPct, Math.max(halfWidthPct, nx));
     const y = Math.min(100 - halfHeightPct, Math.max(halfHeightPct, ny));
+
+    const distLeft = x - halfWidthPct;
+    const distRight = 100 - (x + halfWidthPct);
+    const distTop = y - halfHeightPct;
+    const distBottom = 100 - (y + halfHeightPct);
+    const minDist = Math.min(distLeft, distRight, distTop, distBottom);
+    const nextDeform =
+      minDist < DEFORM_THRESHOLD
+        ? Math.max(minDist / DEFORM_THRESHOLD, 0.2)
+        : 1;
+
+    setDeform(nextDeform);
     onChange(x, y);
   };
 
   const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
     setStart(null);
+    setDeform(1);
     (e.currentTarget as HTMLElement).releasePointerCapture?.(e.pointerId);
   };
 
@@ -70,7 +86,7 @@ function Draggable({
       style={{
         top: `${position.y}%`,
         left: `${position.x}%`,
-        transform: `translate(-50%, -50%) scale(${scale})`,
+        transform: `translate(-50%, -50%) scale(${scale * deform})`,
       }}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -422,7 +422,7 @@ pnpm build
 * **Fonts not applied in export**: the export utility awaits `document.fonts.ready`, but ensure custom fonts are loaded.
 * **Exported image cropped**: export uses `clientWidth`/`clientHeight` to ignore preview zoom. Verify these reflect the expected base size.
 
-* **Dragged element clipped**: drag limits use the element's offset size to keep content fully visible on all edges.
+* **Dragged element clipped**: drag limits use the element's offset size and boundary-aware scaling to keep content fully visible on all edges.
 
 * **WASM background removal slow**: run in Worker and lazy‑load the model (\~5–15MB). Cache after first run.
 * **SVG injection risk**: sanitize or rasterize into canvas before any edit.


### PR DESCRIPTION
## Summary
- shrink draggable items as they approach canvas borders
- document boundary-aware scaling in README and dev doc
- add tests for deformation behavior

## Testing
- `pnpm test`
- `pnpm docs:guard`


------
https://chatgpt.com/codex/tasks/task_e_68ad97f34b98832bb77d28a5a24cd73c