### PR TITLE
refactor: extract Draggable component

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ pnpm dev
   - `Providers.tsx`: wrapper com SessionProvider e ToastProvider
   - `AuthButtons.tsx`: botões de login/logout
   - `CanvasStage.tsx`: preview da imagem OG
+  - `Draggable.tsx`: wrapper arrastável com deformação nas bordas
   - `editor/Toolbar.tsx`: ações de desfazer, refazer, exportar e copiar metatags
   - `editor/Inspector.tsx`: painel lateral com abas (Canvas, Text, Logo, Metadata, Presets, Export)
   - `MetadataPanel.tsx` e `PresetsPanel.tsx`: painéis reutilizados nas respectivas abas

--- a/__tests__/draggable.test.tsx
+++ b/__tests__/draggable.test.tsx
@@ -1,0 +1,61 @@
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import Draggable from '../components/Draggable';
+
+describe('Draggable', () => {
+  beforeAll(() => {
+    // jsdom lacks PointerEvent; map to MouseEvent for tests
+    (window as any).PointerEvent = MouseEvent;
+  });
+
+  it('calls onChange while dragging', () => {
+    const onChange = jest.fn();
+    render(
+      <Draggable position={{ x: 50, y: 50 }} onChange={onChange} zoom={1}>
+        <div data-testid="content" />
+      </Draggable>
+    );
+    const wrapper = screen.getByTestId('content').parentElement as HTMLElement;
+    Object.defineProperty(wrapper, 'offsetWidth', { value: 96 });
+    Object.defineProperty(wrapper, 'offsetHeight', { value: 96 });
+
+    fireEvent.pointerDown(wrapper, { clientX: 100, clientY: 100 });
+    fireEvent.pointerMove(wrapper, { clientX: 160, clientY: 130 });
+    fireEvent.pointerUp(wrapper, { clientX: 160, clientY: 130 });
+
+    expect(onChange).toHaveBeenCalled();
+    const [x, y] = onChange.mock.calls[0];
+    expect(x).not.toBe(50);
+    expect(y).not.toBe(50);
+  });
+
+  const getScale = (el: HTMLElement) => {
+    const match = el.style.transform.match(/scale\(([^)]+)\)/);
+    return match ? parseFloat(match[1]) : 1;
+  };
+
+  it('deforms near edges and restores after release', async () => {
+    const onChange = jest.fn();
+    render(
+      <Draggable position={{ x: 50, y: 50 }} onChange={onChange} zoom={1}>
+        <div data-testid="content" />
+      </Draggable>
+    );
+    const wrapper = screen.getByTestId('content').parentElement as HTMLElement;
+    Object.defineProperty(wrapper, 'offsetWidth', { value: 96 });
+    Object.defineProperty(wrapper, 'offsetHeight', { value: 96 });
+
+    fireEvent.pointerDown(wrapper, { clientX: 50, clientY: 50 });
+    fireEvent.pointerMove(wrapper, { clientX: -1000, clientY: 50 });
+
+    await waitFor(() => {
+      expect(getScale(wrapper)).toBeLessThan(1);
+    });
+
+    fireEvent.pointerUp(wrapper, { clientX: -1000, clientY: 50 });
+
+    await waitFor(() => {
+      expect(getScale(wrapper)).toBeCloseTo(1);
+    });
+  });
+});
+

--- a/components/CanvasStage.tsx
+++ b/components/CanvasStage.tsx
@@ -4,98 +4,12 @@
 import Image from 'next/image';
 import { useMemo } from 'react';
 import { ensureSameOriginImage } from 'lib/urls';
-import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useEditorStore } from 'lib/editorStore';
 import { invertImageColors, blobToDataURL } from 'lib/images';
 import { removeImageBackground } from 'lib/removeBg';
 import { toast } from './ToastProvider';
-
-const BASE_WIDTH = 1200;
-const BASE_HEIGHT = 630;
-
-function Draggable({
-  position,
-  onChange,
-  scale = 1,
-  zoom,
-  children,
-}: {
-  position: { x: number; y: number };
-  onChange: (x: number, y: number) => void;
-  scale?: number;
-  zoom: number;
-  children: ReactNode;
-}) {
-  const [start, setStart] = useState<
-    | {
-      pointer: { x: number; y: number };
-      origin: { x: number; y: number };
-    }
-    | null
-  >(null);
-  const [deform, setDeform] = useState(1);
-  const DEFORM_THRESHOLD = 5;
-
-  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    setStart({
-      pointer: { x: e.clientX, y: e.clientY },
-      origin: { x: position.x, y: position.y },
-    });
-    (e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId);
-  };
-
-  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (!start) return;
-    const dx = e.clientX - start.pointer.x;
-    const dy = e.clientY - start.pointer.y;
-    const el = e.currentTarget as HTMLElement;
-    const currentScale = scale * deform;
-    const width = el.offsetWidth * currentScale;
-    const height = el.offsetHeight * currentScale;
-    const halfWidthPct = (width / BASE_WIDTH) * 50;
-    const halfHeightPct = (height / BASE_HEIGHT) * 50;
-    const nx = start.origin.x + (dx / (BASE_WIDTH * zoom)) * 100;
-    const ny = start.origin.y + (dy / (BASE_HEIGHT * zoom)) * 100;
-    const x = Math.min(100 - halfWidthPct, Math.max(halfWidthPct, nx));
-    const y = Math.min(100 - halfHeightPct, Math.max(halfHeightPct, ny));
-
-    const distLeft = x - halfWidthPct;
-    const distRight = 100 - (x + halfWidthPct);
-    const distTop = y - halfHeightPct;
-    const distBottom = 100 - (y + halfHeightPct);
-    const minDist = Math.min(distLeft, distRight, distTop, distBottom);
-    const nextDeform =
-      minDist < DEFORM_THRESHOLD
-        ? Math.max(minDist / DEFORM_THRESHOLD, 0.2)
-        : 1;
-
-    setDeform(nextDeform);
-    onChange(x, y);
-  };
-
-  const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
-    setStart(null);
-    setDeform(1);
-    (e.currentTarget as HTMLElement).releasePointerCapture?.(e.pointerId);
-  };
-
-  return (
-    <div
-      className={`absolute ${start ? 'outline outline-2 outline-blue-500' : ''}`}
-      style={{
-        top: `${position.y}%`,
-        left: `${position.x}%`,
-        transform: `translate(-50%, -50%) scale(${scale * deform})`,
-      }}
-      onPointerDown={handlePointerDown}
-      onPointerMove={handlePointerMove}
-      onPointerUp={handlePointerUp}
-    >
-      {children}
-    </div>
-  );
-}
+import Draggable, { BASE_WIDTH, BASE_HEIGHT } from './Draggable';
 
 export default function CanvasStage() {
   const containerRef = useRef<HTMLDivElement | null>(null);

--- a/components/Draggable.tsx
+++ b/components/Draggable.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState, type ReactNode } from 'react';
+
+export const BASE_WIDTH = 1200;
+export const BASE_HEIGHT = 630;
+
+export default function Draggable({
+  position,
+  onChange,
+  scale = 1,
+  zoom,
+  children,
+}: {
+  position: { x: number; y: number };
+  onChange: (x: number, y: number) => void;
+  scale?: number;
+  zoom: number;
+  children: ReactNode;
+}) {
+  const [start, setStart] = useState<
+    | {
+        pointer: { x: number; y: number };
+        origin: { x: number; y: number };
+      }
+    | null
+  >(null);
+  const [deform, setDeform] = useState(1);
+  const DEFORM_THRESHOLD = 5;
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setStart({
+      pointer: { x: e.clientX, y: e.clientY },
+      origin: { x: position.x, y: position.y },
+    });
+    (e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId);
+  };
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!start) return;
+    const dx = e.clientX - start.pointer.x;
+    const dy = e.clientY - start.pointer.y;
+    const el = e.currentTarget as HTMLElement;
+    const currentScale = scale * deform;
+    const width = el.offsetWidth * currentScale;
+    const height = el.offsetHeight * currentScale;
+    const halfWidthPct = (width / BASE_WIDTH) * 50;
+    const halfHeightPct = (height / BASE_HEIGHT) * 50;
+    const nx = start.origin.x + (dx / (BASE_WIDTH * zoom)) * 100;
+    const ny = start.origin.y + (dy / (BASE_HEIGHT * zoom)) * 100;
+    const x = Math.min(100 - halfWidthPct, Math.max(halfWidthPct, nx));
+    const y = Math.min(100 - halfHeightPct, Math.max(halfHeightPct, ny));
+
+    const distLeft = x - halfWidthPct;
+    const distRight = 100 - (x + halfWidthPct);
+    const distTop = y - halfHeightPct;
+    const distBottom = 100 - (y + halfHeightPct);
+    const minDist = Math.min(distLeft, distRight, distTop, distBottom);
+    const nextDeform =
+      minDist < DEFORM_THRESHOLD ? Math.max(minDist / DEFORM_THRESHOLD, 0.2) : 1;
+
+    setDeform(nextDeform);
+    onChange(x, y);
+  };
+
+  const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+    setStart(null);
+    setDeform(1);
+    (e.currentTarget as HTMLElement).releasePointerCapture?.(e.pointerId);
+  };
+
+  return (
+    <div
+      className={`absolute ${start ? 'outline outline-2 outline-blue-500' : ''}`}
+      style={{
+        top: `${position.y}%`,
+        left: `${position.x}%`,
+        transform: `translate(-50%, -50%) scale(${scale * deform})`,
+      }}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+    >
+      {children}
+    </div>
+  );
+}
+

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -49,6 +49,7 @@ OGGenerator is a one‑page (expandable) app to **compose Open Graph images** wi
 ├─ components/
 │  ├─ AuthButtons.tsx
 │  ├─ CanvasStage.tsx
+│  ├─ Draggable.tsx
 │  ├─ ErrorBoundary.tsx
 │  ├─ Providers.tsx
 │  ├─ ToastProvider.tsx

--- a/docs/log/2025-08-26.md
+++ b/docs/log/2025-08-26.md
@@ -24,5 +24,6 @@
 - Added numeric X/Y inputs to LogoPanel that mirror drag movements.
 - Hoisted draggable component to preserve state and allow continuous logo dragging.
 - Clamped draggable elements using offset dimensions to prevent edge clipping on all sides.
+- Extracted Draggable component into its own module and added unit tests.
 
 


### PR DESCRIPTION
## Summary
- factor Draggable into its own component and reuse in CanvasStage
- cover Draggable interactions with unit tests
- document new Draggable module in project docs and logs

## Testing
- `pnpm test`
- `pnpm docs:guard`


------
https://chatgpt.com/codex/tasks/task_e_68adb96a2160832bb22f4629c091fbc6