### PR TITLE
feat: add hook for logo keyboard controls

### DIFF
--- a/__tests__/use-logo-keyboard-controls.test.tsx
+++ b/__tests__/use-logo-keyboard-controls.test.tsx
@@ -1,0 +1,35 @@
+import { renderHook, act } from '@testing-library/react';
+import { useLogoKeyboardControls } from '../lib/hooks/useLogoKeyboardControls';
+
+describe('useLogoKeyboardControls', () => {
+  it('updates position and scale on arrow keys', () => {
+    const setLogoScale = jest.fn();
+    const setLogoPosition = jest.fn();
+
+    const { result } = renderHook(() =>
+      useLogoKeyboardControls({
+        logoScale: 1,
+        logoPosition: { x: 50, y: 50 },
+        setLogoScale,
+        setLogoPosition,
+      })
+    );
+
+    act(() => {
+      result.current.onKeyDown({
+        key: 'ArrowRight',
+        preventDefault: jest.fn(),
+      } as any);
+    });
+    expect(setLogoPosition).toHaveBeenCalledWith(51, 50);
+
+    act(() => {
+      result.current.onKeyDown({
+        key: 'ArrowUp',
+        shiftKey: true,
+        preventDefault: jest.fn(),
+      } as any);
+    });
+    expect(setLogoScale).toHaveBeenCalledWith(1.05);
+  });
+});

--- a/components/CanvasStage.tsx
+++ b/components/CanvasStage.tsx
@@ -9,6 +9,7 @@ import { useEditorStore } from 'lib/editorStore';
 import { invertImageColors, blobToDataURL } from 'lib/images';
 import { removeImageBackground } from 'lib/removeBg';
 import { toast } from './ToastProvider';
+import { useLogoKeyboardControls } from 'lib/hooks/useLogoKeyboardControls';
 
 const BASE_WIDTH = 1200;
 const BASE_HEIGHT = 630;
@@ -187,25 +188,12 @@ export default function CanvasStage() {
         ? 'text-right'
         : 'text-left';
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (
-      e.key === 'ArrowUp' ||
-      e.key === 'ArrowDown' ||
-      e.key === 'ArrowLeft' ||
-      e.key === 'ArrowRight'
-    ) {
-      e.preventDefault();
-      if (e.shiftKey && (e.key === 'ArrowUp' || e.key === 'ArrowDown')) {
-        const delta = e.key === 'ArrowUp' ? 0.05 : -0.05;
-        const next = Math.min(3, Math.max(0.2, logoScale + delta));
-        setLogoScale(next);
-      } else {
-        const dx = e.key === 'ArrowLeft' ? -1 : e.key === 'ArrowRight' ? 1 : 0;
-        const dy = e.key === 'ArrowUp' ? -1 : e.key === 'ArrowDown' ? 1 : 0;
-        setLogoPosition(logoPosition.x + dx, logoPosition.y + dy);
-      }
-    }
-  };
+  const { onKeyDown } = useLogoKeyboardControls({
+    logoScale,
+    logoPosition,
+    setLogoScale,
+    setLogoPosition,
+  });
 
 
   const bannerSrc = useMemo(() => ensureSameOriginImage(bannerUrl), [bannerUrl]);
@@ -217,7 +205,7 @@ export default function CanvasStage() {
       tabIndex={0}
       role="img"
       aria-label="OG image preview"
-      onKeyDown={handleKeyDown}
+      onKeyDown={onKeyDown}
     >
       <div
         id="og-canvas"

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -353,6 +353,7 @@ pnpm dev
 
 * [ ] Upload: file input, paste and URL handled; drag‑and‑drop pending.
 * [x] Translate + scale + mask (circle) — drag to translate logo and arrow keys for fine-tuning (hoisted draggable wrapper keeps drag state stable).
+* [x] Arrow-key logo controls extracted into `useLogoKeyboardControls` hook.
 * [x] **Remove Background** via WASM in WebWorker (toggle integrated with helper).
 * [x] **Invert B/W** filter + toggle.
 

--- a/docs/log/2025-08-26.md
+++ b/docs/log/2025-08-26.md
@@ -8,6 +8,8 @@
 - Sync Logo panel X/Y coordinates with canvas drag.
 - Fix logo drag stopping after first movement.
 
+- Extract arrow-key logo controls into reusable `useLogoKeyboardControls` hook.
+
 
 ## Changed
 - Rewrote remove background tests.
@@ -24,5 +26,10 @@
 - Added numeric X/Y inputs to LogoPanel that mirror drag movements.
 - Hoisted draggable component to preserve state and allow continuous logo dragging.
 - Clamped draggable elements using offset dimensions to prevent edge clipping on all sides.
+
+- lib/hooks/useLogoKeyboardControls.ts
+- components/CanvasStage.tsx
+- __tests__/use-logo-keyboard-controls.test.tsx
+- docs/dev_doc.md
 
 

--- a/lib/hooks/useLogoKeyboardControls.ts
+++ b/lib/hooks/useLogoKeyboardControls.ts
@@ -1,0 +1,42 @@
+import { useCallback } from 'react';
+
+interface LogoKeyboardControls {
+  logoScale: number;
+  logoPosition: { x: number; y: number };
+  setLogoScale: (scale: number) => void;
+  setLogoPosition: (x: number, y: number) => void;
+}
+
+export function useLogoKeyboardControls({
+  logoScale,
+  logoPosition,
+  setLogoScale,
+  setLogoPosition,
+}: LogoKeyboardControls) {
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLElement>) => {
+      if (
+        e.key === 'ArrowUp' ||
+        e.key === 'ArrowDown' ||
+        e.key === 'ArrowLeft' ||
+        e.key === 'ArrowRight'
+      ) {
+        e.preventDefault();
+        if (e.shiftKey && (e.key === 'ArrowUp' || e.key === 'ArrowDown')) {
+          const delta = e.key === 'ArrowUp' ? 0.05 : -0.05;
+          const next = Math.min(3, Math.max(0.2, logoScale + delta));
+          setLogoScale(next);
+        } else {
+          const dx = e.key === 'ArrowLeft' ? -1 : e.key === 'ArrowRight' ? 1 : 0;
+          const dy = e.key === 'ArrowUp' ? -1 : e.key === 'ArrowDown' ? 1 : 0;
+          setLogoPosition(logoPosition.x + dx, logoPosition.y + dy);
+        }
+      }
+    },
+    [logoScale, logoPosition, setLogoScale, setLogoPosition]
+  );
+
+  return { onKeyDown };
+}
+
+export default useLogoKeyboardControls;


### PR DESCRIPTION
## Summary
- extract logo keyboard controls into `useLogoKeyboardControls`
- wire hook into `CanvasStage`
- test arrow key scaling and movement

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68adb988fb98832ba73e0895524bb4af