### PR TITLE
refactor: extract canvas zoom hook

### DIFF
--- a/__tests__/useCanvasZoom.test.tsx
+++ b/__tests__/useCanvasZoom.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { useCanvasZoom } from '../lib/hooks/useCanvasZoom';
+
+describe('useCanvasZoom', () => {
+  it('disconnects observer on unmount', () => {
+    const observe = jest.fn();
+    const disconnect = jest.fn();
+    const Original = (global as any).ResizeObserver;
+    (global as any).ResizeObserver = class {
+      observe = observe;
+      disconnect = disconnect;
+    };
+
+    function Test() {
+      const { containerRef } = useCanvasZoom(1200, 630);
+      return <div ref={containerRef} />;
+    }
+
+    const { unmount } = render(<Test />);
+    expect(observe).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(disconnect).toHaveBeenCalledTimes(1);
+
+    (global as any).ResizeObserver = Original;
+  });
+});

--- a/components/CanvasStage.tsx
+++ b/components/CanvasStage.tsx
@@ -4,7 +4,8 @@
 import Image from 'next/image';
 import { useMemo } from 'react';
 import { ensureSameOriginImage } from 'lib/urls';
-import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
+import { useCanvasZoom } from 'lib/hooks/useCanvasZoom';
 import { useEditorStore } from 'lib/editorStore';
 import { invertImageColors, blobToDataURL } from 'lib/images';
 import { removeImageBackground } from 'lib/removeBg';
@@ -98,8 +99,7 @@ function Draggable({
 }
 
 export default function CanvasStage() {
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const [zoom, setZoom] = useState(1);
+  const { containerRef, zoom } = useCanvasZoom(BASE_WIDTH, BASE_HEIGHT);
   const {
     title,
     subtitle,
@@ -124,18 +124,6 @@ export default function CanvasStage() {
   } = useEditorStore();
   const [logoDataUrl, setLogoDataUrl] = useState<string | undefined>(undefined);
 
-  // Resize observer to scale the canvas preview to fit its container
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el || typeof ResizeObserver === 'undefined') return;
-    const ro = new ResizeObserver(() => {
-      const { clientWidth, clientHeight } = el;
-      const scale = Math.min(clientWidth / BASE_WIDTH, clientHeight / BASE_HEIGHT);
-      setZoom(scale * 0.98);
-    });
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, []);
 
   // Prepare logo image applying optional background removal and inversion
   useEffect(() => {

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -348,6 +348,7 @@ pnpm dev
 * [x] Title and subtitle positions stored with `{x,y}` coordinates and draggable on canvas.
 * [x] Layout presets (left/center); 8px baseline grid pending.
 * [x] Local autosave (Zustand persist) and basic keyboard shortcuts for logo.
+* [x] Preview zoom managed by `useCanvasZoom` hook (ResizeObserver).
 
 ### Sprint 3 — Logo Tools (2–3 days)
 

--- a/lib/hooks/useCanvasZoom.ts
+++ b/lib/hooks/useCanvasZoom.ts
@@ -1,0 +1,20 @@
+import { useEffect, useRef, useState } from 'react';
+
+export function useCanvasZoom(baseWidth: number, baseHeight: number) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [zoom, setZoom] = useState(1);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(() => {
+      const { clientWidth, clientHeight } = el;
+      const scale = Math.min(clientWidth / baseWidth, clientHeight / baseHeight);
+      setZoom(scale * 0.98);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [baseWidth, baseHeight]);
+
+  return { zoom, containerRef };
+}


### PR DESCRIPTION
## Summary
- extract canvas resize/zoom logic into reusable `useCanvasZoom` hook
- consume `useCanvasZoom` in `CanvasStage`
- document new hook in dev doc and add cleanup test

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Command "typecheck" not found)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68adb987b7b8832baf52e86829ddc0a3