### PR TITLE
feat: add canvas size presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ pnpm dev
 - [ ] Upload de logo via drag-and-drop
 - [x] Exportação de PNG em múltiplos tamanhos
 - [ ] Presets automáticos de layout e cores
+- [x] Presets de dimensões do canvas
 
 ## How it works
 Projeto construído com **Next.js 15** (App Router) e **React 18**. Os estilos são gerenciados com **Tailwind CSS** e o estado global com **Zustand**.  

--- a/__tests__/canvas-panel.test.tsx
+++ b/__tests__/canvas-panel.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import CanvasPanel from '../components/editor/panels/CanvasPanel';
+import { useEditorStore } from '../lib/editorStore';
+
+describe('CanvasPanel', () => {
+  beforeEach(() => {
+    useEditorStore.getState().reset();
+  });
+
+  it('changes canvas size via presets', () => {
+    render(<CanvasPanel />);
+    fireEvent.click(screen.getByRole('button', { name: /1600 by 900/i }));
+    expect(useEditorStore.getState().width).toBe(1600);
+    expect(useEditorStore.getState().height).toBe(900);
+  });
+});

--- a/__tests__/canvas-stage.test.tsx
+++ b/__tests__/canvas-stage.test.tsx
@@ -22,10 +22,11 @@ describe('CanvasStage', () => {
     expect(banners[0].getAttribute('src')).toContain('banner.png');
   });
 
-  it('exports element has fixed base dimensions', () => {
+  it('uses dimensions from store', () => {
+    useEditorStore.setState({ width: 1600, height: 900 });
     render(<CanvasStage />);
     const canvas = document.getElementById('og-canvas') as HTMLElement;
-    expect(canvas).toHaveStyle({ width: '1200px', height: '630px' });
+    expect(canvas).toHaveStyle({ width: '1600px', height: '900px' });
   });
 
   it('positions the logo at the center by default', () => {

--- a/__tests__/editor-store.test.ts
+++ b/__tests__/editor-store.test.ts
@@ -14,4 +14,10 @@ describe('editorStore position setters', () => {
     useEditorStore.getState().setSubtitlePosition(30, 40);
     expect(useEditorStore.getState().subtitlePosition).toEqual({ x: 30, y: 40 });
   });
+
+  it('updates canvas size', () => {
+    useEditorStore.getState().setSize(1600, 900);
+    expect(useEditorStore.getState().width).toBe(1600);
+    expect(useEditorStore.getState().height).toBe(900);
+  });
 });

--- a/components/CanvasStage.tsx
+++ b/components/CanvasStage.tsx
@@ -9,10 +9,9 @@ import { useLogoKeyboardControls } from 'lib/hooks/useLogoKeyboardControls';
 import { useEditorStore } from 'lib/editorStore';
 import useProcessedLogo from 'lib/hooks/useProcessedLogo';
 
-import Draggable, { BASE_WIDTH, BASE_HEIGHT } from './Draggable';
+import Draggable from './Draggable';
 
 export default function CanvasStage() {
-  const { containerRef, zoom } = useCanvasZoom(BASE_WIDTH, BASE_HEIGHT);
   const {
     title,
     subtitle,
@@ -33,8 +32,11 @@ export default function CanvasStage() {
     setSubtitlePosition,
     invertLogo,
     removeLogoBg,
-    maskLogo
+    maskLogo,
+    width,
+    height,
   } = useEditorStore();
+  const { containerRef, zoom } = useCanvasZoom(width, height);
   const logoDataUrl = useProcessedLogo({
     logoFile,
     logoUrl,
@@ -59,10 +61,13 @@ export default function CanvasStage() {
 
   const bannerSrc = useMemo(() => ensureSameOriginImage(bannerUrl), [bannerUrl]);
 
+  const paddingTop = `${(height / width) * 100}%`;
+
   return (
     <div
       ref={containerRef}
-      className="relative w-full h-0 pt-[52.5%] overflow-hidden rounded-lg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring"
+      className="relative w-full h-0 overflow-hidden rounded-lg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring"
+      style={{ paddingTop }}
       tabIndex={0}
       role="img"
       aria-label="OG image preview"
@@ -72,11 +77,11 @@ export default function CanvasStage() {
         id="og-canvas"
         className={`absolute top-0 left-0 rounded-lg shadow-md border ${themeClasses}`}
         style={{
-          width: BASE_WIDTH,
-          height: BASE_HEIGHT,
+          width,
+          height,
           transform: `scale(${zoom})`,
           transformOrigin: 'top left',
-          borderColor: accentColor
+          borderColor: accentColor,
         }}
       >
         {bannerSrc && (
@@ -93,6 +98,8 @@ export default function CanvasStage() {
           position={titlePosition}
           onChange={setTitlePosition}
           zoom={zoom}
+          baseWidth={width}
+          baseHeight={height}
         >
           <h1
             className={`font-bold leading-tight break-words ${textAlignClass}`}
@@ -105,6 +112,8 @@ export default function CanvasStage() {
           position={subtitlePosition}
           onChange={setSubtitlePosition}
           zoom={zoom}
+          baseWidth={width}
+          baseHeight={height}
         >
           <p className={`text-lg md:text-2xl max-w-prose ${textAlignClass}`}>
             {subtitle}
@@ -116,6 +125,8 @@ export default function CanvasStage() {
             onChange={setLogoPosition}
             scale={logoScale}
             zoom={zoom}
+            baseWidth={width}
+            baseHeight={height}
           >
             <Image
               src={logoDataUrl}

--- a/components/Draggable.tsx
+++ b/components/Draggable.tsx
@@ -11,12 +11,16 @@ export default function Draggable({
   scale = 1,
   zoom,
   children,
+  baseWidth = BASE_WIDTH,
+  baseHeight = BASE_HEIGHT,
 }: {
   position: { x: number; y: number };
   onChange: (x: number, y: number) => void;
   scale?: number;
   zoom: number;
   children: ReactNode;
+  baseWidth?: number;
+  baseHeight?: number;
 }) {
   const [start, setStart] = useState<
     | {
@@ -45,10 +49,10 @@ export default function Draggable({
     const currentScale = scale * deform;
     const width = el.offsetWidth * currentScale;
     const height = el.offsetHeight * currentScale;
-    const halfWidthPct = (width / BASE_WIDTH) * 50;
-    const halfHeightPct = (height / BASE_HEIGHT) * 50;
-    const nx = start.origin.x + (dx / (BASE_WIDTH * zoom)) * 100;
-    const ny = start.origin.y + (dy / (BASE_HEIGHT * zoom)) * 100;
+    const halfWidthPct = (width / baseWidth) * 50;
+    const halfHeightPct = (height / baseHeight) * 50;
+    const nx = start.origin.x + (dx / (baseWidth * zoom)) * 100;
+    const ny = start.origin.y + (dy / (baseHeight * zoom)) * 100;
     const x = Math.min(100 - halfWidthPct, Math.max(halfWidthPct, nx));
     const y = Math.min(100 - halfHeightPct, Math.max(halfHeightPct, ny));
 

--- a/components/editor/panels/CanvasPanel.tsx
+++ b/components/editor/panels/CanvasPanel.tsx
@@ -1,6 +1,12 @@
 "use client";
 import { useEditorStore } from "lib/editorStore";
 
+const SIZE_PRESETS = {
+  "1200x630": { width: 1200, height: 630 },
+  "1600x900": { width: 1600, height: 900 },
+  "1920x1005": { width: 1920, height: 1005 },
+};
+
 export default function CanvasPanel() {
   const {
     theme,
@@ -11,7 +17,14 @@ export default function CanvasPanel() {
     setVertical,
     accentColor,
     setAccentColor,
+    width,
+    height,
+    setSize,
   } = useEditorStore();
+
+  const current = (Object.entries(SIZE_PRESETS).find(
+    ([, v]) => v.width === width && v.height === height
+  ) || ["", { width: 0, height: 0 }])[0];
 
   return (
     <section className="space-y-3">
@@ -83,6 +96,29 @@ export default function CanvasPanel() {
           aria-label="Accent Color"
         />
       </label>
+
+      <div>
+        <span className="text-sm" id="size-label">
+          Size
+        </span>
+        <div
+          className="mt-1 grid grid-cols-3 gap-2"
+          role="group"
+          aria-labelledby="size-label"
+        >
+          {Object.entries(SIZE_PRESETS).map(([key, value]) => (
+            <button
+              key={key}
+              className={`btn ${current === key ? "btn-primary" : ""}`}
+              aria-label={`Canvas size ${key.replace("x", " by ")}`}
+              aria-pressed={current === key}
+              onClick={() => setSize(value.width, value.height)}
+            >
+              {key.replace("x", "×")}
+            </button>
+          ))}
+        </div>
+      </div>
     </section>
   );
 }

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -87,7 +87,7 @@ OGGenerator is a one‑page (expandable) app to **compose Open Graph images** wi
 
 **Canvas Stage**
 
-* Base size (1200×630). Zoom to fit viewport, render at 2× for crisp export.
+* Canvas size presets (1200×630, 1600×900, 1920×1005). Zoom to fit viewport, render at 2× for crisp export.
 * 
 * Text: Title + Subtitle with smart clamp, max width, balance (`text-wrap: balance`).
 * Layout Presets: horizontal left/center/right and vertical top/center/bottom alignment with 8px baseline.
@@ -152,7 +152,7 @@ pnpm dev
 * [ ] **Remove Backgroun** processo lento, Mostrar loading.
 * [ ] **Invert B/W** improve.
 * [ ] Hi‑DPI export (2× then downscale) to PNG.
-* [ ] **Size presets**, add diferent proportions and update Canvas (portrait, landscape, box)
+* [x] **Size presets**: added dimension presets and updated Canvas
 * [ ] Copy OG/Twitter meta block with toast feedback.
 * [ ] **Tooltips** and polished focus states; basic ARIA labels present.
 * [ ] **Toasts** for every user action.

--- a/docs/log/2025-08-30.md
+++ b/docs/log/2025-08-30.md
@@ -1,0 +1,15 @@
+# 2025-08-30
+
+## Summary
+- Added canvas size presets with selector in editor and state store.
+
+## Changed
+- lib/editorStore.ts
+- components/CanvasStage.tsx
+- components/Draggable.tsx
+- components/editor/panels/CanvasPanel.tsx
+- README.md
+- docs/dev_doc.md
+- __tests__/canvas-stage.test.tsx
+- __tests__/canvas-panel.test.tsx
+- __tests__/editor-store.test.ts

--- a/lib/editorStore.ts
+++ b/lib/editorStore.ts
@@ -14,6 +14,8 @@ interface EditorData {
   layout: 'left' | 'center' | 'right';
   vertical: 'top' | 'center' | 'bottom';
   accentColor: string;
+  width: number;
+  height: number;
   bannerUrl?: string;
   logoFile?: File;
   logoUrl?: string;
@@ -44,6 +46,7 @@ export interface EditorState extends EditorData {
   toggleInvertLogo: () => void;
   toggleRemoveLogoBg: () => void;
   toggleMaskLogo: () => void;
+  setSize: (width: number, height: number) => void;
   addPreset: (preset: Preset) => void;
   applyPreset: (preset: Preset) => void;
   undo: () => void;
@@ -62,6 +65,8 @@ const initialState: EditorData = {
   layout: 'left',
   vertical: 'center',
   accentColor: '#3b82f6',
+  width: 1200,
+  height: 630,
   logoPosition: { x: 50, y: 50 },
   logoScale: 1,
   invertLogo: false,
@@ -87,6 +92,8 @@ export const useEditorStore = create<EditorState>()(
         layout,
         vertical,
         accentColor,
+        width,
+        height,
         bannerUrl,
         logoFile,
         logoUrl,
@@ -107,6 +114,8 @@ export const useEditorStore = create<EditorState>()(
         layout,
         vertical,
         accentColor,
+        width,
+        height,
         bannerUrl,
         logoFile,
         logoUrl,
@@ -137,6 +146,7 @@ export const useEditorStore = create<EditorState>()(
         setLayout: (value) => apply({ layout: value }),
         setVertical: (value) => apply({ vertical: value }),
         setAccentColor: (value) => apply({ accentColor: value }),
+        setSize: (width, height) => apply({ width, height }),
         setBannerUrl: (value) => apply({ bannerUrl: value }),
         setLogoFile: (file) => apply({ logoFile: file, logoUrl: undefined }),
         setLogoUrl: (url) => apply({ logoUrl: url, logoFile: undefined }),
@@ -185,6 +195,8 @@ export const useEditorStore = create<EditorState>()(
         layout: state.layout,
         vertical: state.vertical,
         accentColor: state.accentColor,
+        width: state.width,
+        height: state.height,
         bannerUrl: state.bannerUrl,
         logoUrl: state.logoUrl,
         logoPosition: state.logoPosition,


### PR DESCRIPTION
## Summary
- manage canvas width and height in editor store
- allow selecting size presets in canvas panel
- document new options and test preset selection

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm docs:guard`


------
https://chatgpt.com/codex/tasks/task_e_68adcb91c884832b81aeae5006646d55