### PR TITLE
feat: add logo processing loading state

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ pnpm dev
 - [x] Autenticação com Google e GitHub (NextAuth)
 - [ ] Provedores adicionais (Twitter, Facebook, Instagram)
 - [x] Editor com título, subtítulo e logo arrastável
-- [x] Remoção de fundo, inversão B/W e máscara circular do logo
+- [x] Remoção de fundo, inversão B/W e máscara circular do logo (com loading)
 - [ ] Upload de logo via drag-and-drop
 - [x] Exportação de PNG em múltiplos tamanhos
 - [ ] Presets automáticos de layout e cores
@@ -74,7 +74,7 @@ Os testes residem em `__tests__/` e cobrem utilitários e fluxos principais.
 - [ ] Provedores Twitter e Facebook
 - [x] Canvas com título, subtítulo e logo arrastável
 - [ ] Upload de logo via drag-and-drop
-- [x] Remoção de fundo e inversão B/W
+- [x] Remoção de fundo, inversão B/W e loading do logo
 - [ ] Hi‑DPI export (2×)
 - [ ] Templates de layout e cores
 

--- a/__tests__/logo-panel.test.tsx
+++ b/__tests__/logo-panel.test.tsx
@@ -1,9 +1,20 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import LogoPanel from '../components/editor/panels/LogoPanel';
 import { useEditorStore } from '../lib/editorStore';
+import useProcessedLogo from '../lib/hooks/useProcessedLogo';
+
+jest.mock('../lib/hooks/useProcessedLogo', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ logoDataUrl: undefined, loading: false })),
+}));
 
 describe('LogoPanel', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
+    (useProcessedLogo as jest.Mock).mockReturnValue({
+      logoDataUrl: undefined,
+      loading: false,
+    });
     useEditorStore.getState().reset();
     useEditorStore.setState({
       logoFile: undefined,
@@ -77,6 +88,15 @@ describe('LogoPanel', () => {
     fireEvent.click(screen.getByText(/reset/i));
     expect(useEditorStore.getState().logoScale).toBe(1);
     expect(useEditorStore.getState().logoPosition).toEqual({ x: 50, y: 50 });
+  });
+
+  it('shows spinner while processing', () => {
+    (useProcessedLogo as jest.Mock).mockReturnValue({
+      logoDataUrl: undefined,
+      loading: true,
+    });
+    render(<LogoPanel />);
+    expect(screen.getByLabelText(/processing logo/i)).toBeInTheDocument();
   });
 });
 

--- a/__tests__/useProcessedLogo.test.ts
+++ b/__tests__/useProcessedLogo.test.ts
@@ -36,7 +36,9 @@ describe('useProcessedLogo', () => {
         invertLogo: false,
       })
     );
-    await waitFor(() => expect(result.current).toBe('removed-url'));
+    await waitFor(() => expect(result.current.loading).toBe(true));
+    await waitFor(() => expect(result.current.logoDataUrl).toBe('removed-url'));
+    expect(result.current.loading).toBe(false);
     expect(removeImageBackground).toHaveBeenCalledWith('logo.png');
   });
 
@@ -51,7 +53,9 @@ describe('useProcessedLogo', () => {
         invertLogo: true,
       })
     );
-    await waitFor(() => expect(result.current).toBe('inverted-url'));
+    await waitFor(() => expect(result.current.loading).toBe(true));
+    await waitFor(() => expect(result.current.logoDataUrl).toBe('inverted-url'));
+    expect(result.current.loading).toBe(false);
     expect(removeImageBackground).not.toHaveBeenCalled();
     expect(invertImageColors).toHaveBeenCalledWith('normalized-url');
   });

--- a/components/CanvasStage.tsx
+++ b/components/CanvasStage.tsx
@@ -35,7 +35,7 @@ export default function CanvasStage() {
     removeLogoBg,
     maskLogo
   } = useEditorStore();
-  const logoDataUrl = useProcessedLogo({
+  const { logoDataUrl } = useProcessedLogo({
     logoFile,
     logoUrl,
     removeLogoBg,

--- a/components/editor/panels/LogoPanel.tsx
+++ b/components/editor/panels/LogoPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEditorStore } from "lib/editorStore";
+import useProcessedLogo from "lib/hooks/useProcessedLogo";
 import type { ChangeEvent } from "react";
 
 export default function LogoPanel() {
@@ -13,7 +14,18 @@ export default function LogoPanel() {
     setLogoScale,
     logoPosition,
     setLogoPosition,
+    logoFile,
+    logoUrl,
+    removeLogoBg,
+    invertLogo,
   } = useEditorStore();
+
+  const { loading } = useProcessedLogo({
+    logoFile,
+    logoUrl,
+    removeLogoBg,
+    invertLogo,
+  });
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -79,6 +91,33 @@ export default function LogoPanel() {
           From URL
         </button>
       </div>
+      {loading && (
+        <div
+          role="status"
+          aria-label="Processing logo"
+          className="flex items-center"
+        >
+          <svg
+            className="animate-spin h-5 w-5 text-current"
+            viewBox="0 0 24 24"
+          >
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+              fill="none"
+            />
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+            />
+          </svg>
+        </div>
+      )}
       <div className="grid grid-cols-3 gap-2">
         <button className="btn" aria-label="Remove background from logo" onClick={toggleRemoveLogoBg}>
           Remove BG

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -63,7 +63,7 @@ OGGenerator is a one‑page (expandable) app to **compose Open Graph images** wi
 │  ├─ randomStyle.ts
 │  ├─ removeBg.ts                              # WASM loader + pipeline
 │  └─ hooks/
-│     └─ useProcessedLogo.ts                   # prepares logo image (BG removal + inversion)
+│     └─ useProcessedLogo.ts                   # prepares logo image (BG removal + inversion) and exposes loading state
 ├─ state/
 │  └─ editorStore.ts                           # re-export for convenience
 ├─ workers/
@@ -101,6 +101,7 @@ OGGenerator is a one‑page (expandable) app to **compose Open Graph images** wi
 * **Remove Background**: client‑side WASM U^2‑Net; fallback API route.
 * **Invert B/W**: canvas filter (luminance threshold + invert) — preview toggle.
 * **Mask (Circle)**: optional clipPath for avatars.
+* **Loading indicator**: spinner while logo processing is running.
 * **Position**: X/Y sliders for precise placement; Undo/Redo available via global toolbar.
 
 ---
@@ -149,7 +150,7 @@ pnpm dev
 * [ ] **Background**: solid/gradient/image (with object‑fit cover, position).
 * [ ] **Layout presets**:  Add more, reset, auto-layout, auto fit
 * [ ] **Resize on boundries**: Improve featur, it flicks when dragging close to border
-* [ ] **Remove Backgroun** processo lento, Mostrar loading.
+* [x] **Remove Backgroun** processo lento, Mostrar loading.
 * [ ] **Invert B/W** improve.
 * [ ] Hi‑DPI export (2× then downscale) to PNG.
 * [ ] **Size presets**, add diferent proportions and update Canvas (portrait, landscape, box)

--- a/docs/log/2025-08-30.md
+++ b/docs/log/2025-08-30.md
@@ -1,0 +1,13 @@
+# 2025-08-30
+
+## Summary
+- Expose loading state from logo processing hook and show spinner in logo panel.
+
+## Changed
+- lib/hooks/useProcessedLogo.ts
+- components/CanvasStage.tsx
+- components/editor/panels/LogoPanel.tsx
+- __tests__/useProcessedLogo.test.ts
+- __tests__/logo-panel.test.tsx
+- README.md
+- docs/dev_doc.md

--- a/lib/hooks/useProcessedLogo.ts
+++ b/lib/hooks/useProcessedLogo.ts
@@ -18,6 +18,7 @@ export default function useProcessedLogo({
   invertLogo,
 }: Options) {
   const [logoDataUrl, setLogoDataUrl] = useState<string | undefined>(undefined);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -26,8 +27,11 @@ export default function useProcessedLogo({
       let source: string | Blob | undefined = logoFile ?? logoUrl;
       if (!source) {
         setLogoDataUrl(undefined);
+        setLoading(false);
         return;
       }
+
+      setLoading(true);
 
       try {
         if (removeLogoBg) {
@@ -50,6 +54,8 @@ export default function useProcessedLogo({
         const message = e instanceof Error ? e.message : 'Erro ao processar a imagem.';
         toast({ message, variant: 'error' });
         if (!cancelled) setLogoDataUrl(undefined);
+      } finally {
+        if (!cancelled) setLoading(false);
       }
     };
 
@@ -59,6 +65,6 @@ export default function useProcessedLogo({
     };
   }, [logoFile, logoUrl, removeLogoBg, invertLogo]);
 
-  return logoDataUrl;
+  return { logoDataUrl, loading };
 }
 


### PR DESCRIPTION
## Summary
- expose `loading` flag from `useProcessedLogo`
- show spinner in LogoPanel while logo processing runs
- document loading indicator and test coverage

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm docs:guard`


------
https://chatgpt.com/codex/tasks/task_e_68adcb7f48e8832b9bd6ed0a011d29bf