### PR TITLE
Clamp Draggable positions to canvas bounds

### DIFF
--- a/__tests__/draggable.test.tsx
+++ b/__tests__/draggable.test.tsx
@@ -1,5 +1,5 @@
 import { render, fireEvent, screen, waitFor } from '@testing-library/react';
-import Draggable from '../components/Draggable';
+import Draggable, { BASE_WIDTH, BASE_HEIGHT } from '../components/Draggable';
 
 describe('Draggable', () => {
   beforeAll(() => {
@@ -56,6 +56,35 @@ describe('Draggable', () => {
     await waitFor(() => {
       expect(getScale(wrapper)).toBeCloseTo(1);
     });
+  });
+
+  it('clamps position within canvas bounds', () => {
+    const onChange = jest.fn();
+    render(
+      <Draggable position={{ x: 50, y: 50 }} onChange={onChange} zoom={1}>
+        <div data-testid="content" />
+      </Draggable>
+    );
+    const wrapper = screen.getByTestId('content').parentElement as HTMLElement;
+    Object.defineProperty(wrapper, 'offsetWidth', { value: 96 });
+    Object.defineProperty(wrapper, 'offsetHeight', { value: 96 });
+
+    fireEvent.pointerDown(wrapper, { clientX: 50, clientY: 50 });
+
+    fireEvent.pointerMove(wrapper, { clientX: -1000, clientY: -1000 });
+    const halfWidthPct = (96 / BASE_WIDTH) * 50;
+    const halfHeightPct = (96 / BASE_HEIGHT) * 50;
+    let [x, y] = onChange.mock.calls.at(-1) as [number, number];
+    expect(x).toBeCloseTo(halfWidthPct);
+    expect(y).toBeCloseTo(halfHeightPct);
+
+    fireEvent.pointerUp(wrapper, { clientX: -1000, clientY: -1000 });
+
+    fireEvent.pointerDown(wrapper, { clientX: 50, clientY: 50 });
+    fireEvent.pointerMove(wrapper, { clientX: 5000, clientY: 5000 });
+    [x, y] = onChange.mock.calls.at(-1) as [number, number];
+    expect(x).toBeCloseTo(100 - halfWidthPct);
+    expect(y).toBeCloseTo(100 - halfHeightPct);
   });
 });
 

--- a/components/Draggable.tsx
+++ b/components/Draggable.tsx
@@ -49,8 +49,10 @@ export default function Draggable({
     const halfHeightPct = (height / BASE_HEIGHT) * 50;
     const nx = start.origin.x + (dx / (BASE_WIDTH * zoom)) * 100;
     const ny = start.origin.y + (dy / (BASE_HEIGHT * zoom)) * 100;
-    const x = Math.min(100 - halfWidthPct, Math.max(halfWidthPct, nx));
-    const y = Math.min(100 - halfHeightPct, Math.max(halfHeightPct, ny));
+    const clamp = (v: number, min: number, max: number) =>
+      Math.min(Math.max(v, min), max);
+    const x = clamp(nx, Math.min(halfWidthPct, 100 - halfWidthPct), Math.max(halfWidthPct, 100 - halfWidthPct));
+    const y = clamp(ny, Math.min(halfHeightPct, 100 - halfHeightPct), Math.max(halfHeightPct, 100 - halfHeightPct));
 
     const distLeft = x - halfWidthPct;
     const distRight = 100 - (x + halfWidthPct);

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -95,7 +95,7 @@ OGGenerator is a one‑page (expandable) app to **compose Open Graph images** wi
 
 **Logo Controls**
 
-* **Translate**: click‑drag in canvas; fine‑tune with arrow keys (Shift = 10×).
+* **Translate**: click‑drag in canvas with positions clamped to bounds; fine‑tune with arrow keys (Shift = 10×).
 * **Scale**: pinch/scroll over logo; numeric slider with min/max.
 * **Manual Position**: X/Y number inputs in Logo panel update with drag.
 * **Remove Background**: client‑side WASM U^2‑Net; fallback API route.


### PR DESCRIPTION
## Summary
- clamp drag coordinates within canvas bounds in Draggable component
- add regression test for clamped positions
- document clamped drag behavior in developer docs

## Testing
- `pnpm test __tests__/draggable.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68adcb7b0a90832b8d591962a319d4a1