### PR TITLE
feat: add avatar dropdown with persisted session

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ pnpm dev
 
 ## Features
 - [x] Autenticação com Google e GitHub (NextAuth)
+- [x] Avatar e menu de sessão persistente
 - [ ] Provedores adicionais (Twitter, Facebook, Instagram)
 - [x] Editor com título, subtítulo e logo arrastável
 - [x] Remoção de fundo, inversão B/W e máscara circular do logo
@@ -71,6 +72,7 @@ Os testes residem em `__tests__/` e cobrem utilitários e fluxos principais.
 ## Roadmap & Status
 - [x] Bootstrap Next.js + Tailwind + Zustand
 - [x] Autenticação Google e GitHub
+- [x] Avatar e menu de sessão persistente
 - [ ] Provedores Twitter e Facebook
 - [x] Canvas com título, subtítulo e logo arrastável
 - [ ] Upload de logo via drag-and-drop

--- a/__tests__/auth-buttons.test.tsx
+++ b/__tests__/auth-buttons.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import AuthButtons from '../components/AuthButtons';
-import { useSession } from 'next-auth/react';
+import { useSession, signIn, signOut } from 'next-auth/react';
 
 jest.mock('next-auth/react', () => ({
   useSession: jest.fn(),
@@ -9,13 +9,41 @@ jest.mock('next-auth/react', () => ({
 }));
 
 const mockedUseSession = useSession as jest.MockedFunction<typeof useSession>;
+const mockedSignIn = signIn as jest.MockedFunction<typeof signIn>;
+const mockedSignOut = signOut as jest.MockedFunction<typeof signOut>;
 
 describe('AuthButtons', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it('renders loading placeholder with aria attributes', () => {
     mockedUseSession.mockReturnValue({ data: null, status: 'loading' } as any);
     render(<AuthButtons />);
     const loadingBtn = screen.getByRole('button', { name: /carregando/i });
     expect(loadingBtn).toBeDisabled();
     expect(loadingBtn).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('triggers signIn when clicking Entrar', () => {
+    mockedUseSession.mockReturnValue({ data: null, status: 'unauthenticated' } as any);
+    render(<AuthButtons />);
+    const signInBtn = screen.getByRole('button', { name: /entrar/i });
+    fireEvent.click(signInBtn);
+    expect(mockedSignIn).toHaveBeenCalled();
+  });
+
+  it('shows avatar dropdown and calls signOut', async () => {
+    mockedUseSession.mockReturnValue({
+      data: { user: { name: 'Alice', image: 'avatar.png' } },
+      status: 'authenticated',
+    } as any);
+    render(<AuthButtons />);
+    const avatarImg = screen.getByRole('img', { name: /alice/i });
+    expect(avatarImg).toBeInTheDocument();
+    fireEvent.click(avatarImg.closest('button')!);
+    const signOutBtn = await screen.findByRole('menuitem', { name: /sair/i });
+    fireEvent.click(signOutBtn);
+    expect(mockedSignOut).toHaveBeenCalled();
   });
 });

--- a/components/AuthButtons.tsx
+++ b/components/AuthButtons.tsx
@@ -1,14 +1,34 @@
 "use client";
 
 import { signIn, signOut, useSession } from 'next-auth/react';
+import { useEffect, useRef, useState } from 'react';
+import { useSessionStore } from '../lib/sessionStore';
 
 /**
- * Renders sign in/out buttons based on the user's session state. When not
- * authenticated the user can choose one of the available providers on the
- * default NextAuth sign in page.
+ * Renders sign in/out controls. When authenticated it shows the user's avatar
+ * with a dropdown menu containing the sign-out action. The current session is
+ * persisted to a Zustand store so other components can access it without the
+ * NextAuth context.
  */
 export default function AuthButtons() {
   const { data: session, status } = useSession();
+  const setSession = useSessionStore((s) => s.setSession);
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setSession(session);
+  }, [session, setSession]);
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    if (open) document.addEventListener('click', handleClick);
+    return () => document.removeEventListener('click', handleClick);
+  }, [open]);
 
   if (status === 'loading') {
     return (
@@ -47,16 +67,39 @@ export default function AuthButtons() {
   }
 
   return (
-    <div className="space-x-3">
+    <div className="relative" ref={menuRef}>
       {session ? (
         <>
-          <span className="text-sm font-medium">Olá, {session.user?.name || 'usuário'}</span>
           <button
-            onClick={() => signOut()}
-            className="rounded-md bg-gray-200 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-300"
+            onClick={() => setOpen((o) => !o)}
+            className="flex h-8 w-8 items-center justify-center rounded-full focus:outline-none"
           >
-            Sair
+            {session.user?.image ? (
+              <img
+                src={session.user.image}
+                alt={session.user?.name ?? 'avatar'}
+                className="h-8 w-8 rounded-full"
+              />
+            ) : (
+              <span className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-300 text-sm font-medium text-gray-700">
+                {(session.user?.name ?? 'U').charAt(0).toUpperCase()}
+              </span>
+            )}
           </button>
+          {open && (
+            <div
+              role="menu"
+              className="absolute right-0 mt-2 w-32 rounded-md border bg-white shadow-lg"
+            >
+              <button
+                role="menuitem"
+                onClick={() => signOut()}
+                className="block w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100"
+              >
+                Sair
+              </button>
+            </div>
+          )}
         </>
       ) : (
         <button

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -142,7 +142,7 @@ pnpm dev
 ## 13) TODO
 
 * [ ] Add shadcn/ui primitives (Button, Slider, Dialog, Toast, Tooltip).
-* [ ] **Session header**: AuthButtons handles sign-in/out; avatar + menu pending.
+* [x] **Session header**: AuthButtons shows avatar with dropdown and persists session.
 * [ ] Choose storage strategy (KV + Blob *or* Supabase) and implement abstraction.
 * [ ] Save/load **Design** documents per user.
 * [ ] **Text layers** (Title/Subtitle) with clamp + balance (basic inputs exist).
@@ -172,3 +172,11 @@ pnpm dev
 
 ---
 
+
+# Persist session in Zustand
+Date: 2025-08-26
+Status: accepted
+Context: Header needed persisted auth state to show avatar dropdown across routes.
+Decision: Introduced `lib/sessionStore` with Zustand `persist` and synced `AuthButtons` via `useSession`.
+Consequences: Session info lives in localStorage and is accessible app-wide; must clear store on sign-out.
+Links: PR TBD

--- a/lib/sessionStore.ts
+++ b/lib/sessionStore.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { Session } from 'next-auth';
+
+interface SessionState {
+  session: Session | null;
+  setSession: (session: Session | null) => void;
+}
+
+/**
+ * Global session store so auth info is accessible outside of the NextAuth context
+ * and survives page reloads. Stored in localStorage via Zustand's persist middleware.
+ */
+export const useSessionStore = create<SessionState>()(
+  persist(
+    (set) => ({
+      session: null,
+      setSession: (session) => set({ session }),
+    }),
+    {
+      name: 'session-store',
+    }
+  )
+);


### PR DESCRIPTION
## Summary
- display user avatar with dropdown sign-out menu
- persist session details via Zustand store
- document session header and add auth button tests

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm docs:guard`


------
https://chatgpt.com/codex/tasks/task_e_68adcb4daf78832b9c219d65319eb6c1