### PR TITLE
feat: add editor persistence API

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ pnpm dev
 - [ ] Upload de logo via drag-and-drop
 - [x] Exportação de PNG em múltiplos tamanhos
 - [ ] Presets automáticos de layout e cores
+- [x] API de persistência do editor (CRUD)
 
 ## How it works
-Projeto construído com **Next.js 15** (App Router) e **React 18**. Os estilos são gerenciados com **Tailwind CSS** e o estado global com **Zustand**.  
-A autenticacão é feita via **NextAuth** e a remoção de fundo usa um **WebWorker** com modelo WASM.
+Projeto construído com **Next.js 15** (App Router) e **React 18**. Os estilos são gerenciados com **Tailwind CSS** e o estado global com **Zustand**.
+A autenticacão é feita via **NextAuth**, a remoção de fundo usa um **WebWorker** com modelo WASM e o estado do editor pode ser serializado e salvo em `/api/design`.
 
 Estrutura principal:
 - `app/` – rotas e páginas (editor em `app/(editor)/page.tsx`)

--- a/__tests__/api.design.route.test.ts
+++ b/__tests__/api.design.route.test.ts
@@ -1,0 +1,72 @@
+import {
+  useEditorStore,
+  serializeEditorState,
+  deserializeEditorState,
+} from '../lib/editorStore';
+
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: any, init?: { status?: number }) => ({
+      json: async () => body,
+      status: init?.status ?? 200,
+    }),
+  },
+}));
+
+describe('CRUD /api/design', () => {
+  beforeEach(() => {
+    useEditorStore.getState().reset();
+  });
+
+  afterEach(() => {
+    const { __db } = require('../app/api/design/route');
+    __db.clear();
+  });
+
+  it('creates and retrieves a design', async () => {
+    const state = deserializeEditorState(
+      serializeEditorState(useEditorStore.getState())
+    );
+    state.title = 'Saved';
+    const { POST, GET } = await import('../app/api/design/route');
+    const res = await POST({
+      json: async () => state,
+    } as Request);
+    const { id } = await res.json();
+    const getRes = await GET({
+      url: `http://localhost/api/design?id=${id}`,
+    } as Request);
+    const fetched = await getRes.json();
+    expect(fetched.title).toBe('Saved');
+  });
+
+  it('updates and deletes a design', async () => {
+    const base = deserializeEditorState(
+      serializeEditorState(useEditorStore.getState())
+    );
+    const { POST, GET, PUT, DELETE } = await import(
+      '../app/api/design/route'
+    );
+    const created = await POST({
+      json: async () => base,
+    } as Request);
+    const { id } = await created.json();
+    base.title = 'Updated';
+    await PUT({
+      url: `http://localhost/api/design?id=${id}`,
+      json: async () => base,
+    } as Request);
+    const after = await GET({
+      url: `http://localhost/api/design?id=${id}`,
+    } as Request);
+    const fetched = await after.json();
+    expect(fetched.title).toBe('Updated');
+    await DELETE({
+      url: `http://localhost/api/design?id=${id}`,
+    } as Request);
+    const missing = await GET({
+      url: `http://localhost/api/design?id=${id}`,
+    } as Request);
+    expect(missing.status).toBe(404);
+  });
+});

--- a/__tests__/editor-store.test.ts
+++ b/__tests__/editor-store.test.ts
@@ -1,4 +1,8 @@
-import { useEditorStore } from '../lib/editorStore';
+import {
+  useEditorStore,
+  serializeEditorState,
+  deserializeEditorState,
+} from '../lib/editorStore';
 
 describe('editorStore position setters', () => {
   beforeEach(() => {
@@ -13,5 +17,19 @@ describe('editorStore position setters', () => {
   it('updates subtitle position', () => {
     useEditorStore.getState().setSubtitlePosition(30, 40);
     expect(useEditorStore.getState().subtitlePosition).toEqual({ x: 30, y: 40 });
+  });
+});
+
+describe('editorStore serialization', () => {
+  beforeEach(() => {
+    useEditorStore.getState().reset();
+  });
+
+  it('round-trips state without File objects', () => {
+    useEditorStore.getState().setTitle('Hello');
+    const json = serializeEditorState(useEditorStore.getState());
+    const restored = deserializeEditorState(json);
+    expect(restored.title).toBe('Hello');
+    expect(restored.logoFile).toBeUndefined();
   });
 });

--- a/app/api/design/route.ts
+++ b/app/api/design/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+import { serializeEditorState, deserializeEditorState, EditorData } from '../../../lib/editorStore';
+import { randomUUID } from 'crypto';
+
+const db = new Map<string, string>();
+export const __db = db;
+
+export async function POST(req: Request) {
+  const data = (await req.json()) as EditorData;
+  const id = randomUUID();
+  db.set(id, serializeEditorState(data));
+  return NextResponse.json({ id });
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const id = searchParams.get('id');
+  if (!id) return NextResponse.json({ error: 'Missing id' }, { status: 400 });
+  const raw = db.get(id);
+  if (!raw) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  return NextResponse.json(deserializeEditorState(raw));
+}
+
+export async function PUT(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const id = searchParams.get('id');
+  if (!id) return NextResponse.json({ error: 'Missing id' }, { status: 400 });
+  if (!db.has(id)) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  const data = (await req.json()) as EditorData;
+  db.set(id, serializeEditorState(data));
+  return NextResponse.json({ id });
+}
+
+export async function DELETE(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const id = searchParams.get('id');
+  if (!id) return NextResponse.json({ error: 'Missing id' }, { status: 400 });
+  if (!db.has(id)) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  db.delete(id);
+  return NextResponse.json({ ok: true });
+}

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -19,6 +19,7 @@ OGGenerator is a one‑page (expandable) app to **compose Open Graph images** wi
 * **Auth:** NextAuth.js (Auth.js) with OAuth providers (see configuration below).
 * **Storage:**
   * Local state: Zustand with undo/redo history and localStorage persistence.
+  * API routes persist serialized editor state (`/api/design`).
   * Object storage for uploads (logo): Vercel Blob **or** Supabase Storage/S3‑compatible bucket.
 * **Image Processing:** HTMLCanvas + OffscreenCanvas + WebWorker. For **background removal**, a dedicated worker lazy-loads `@imgly/background-removal` and caches the WASM model.
 * **Validation/Config:** Zod + TypeScript.
@@ -35,7 +36,8 @@ OGGenerator is a one‑page (expandable) app to **compose Open Graph images** wi
 │  ├─ api/
 │  │  ├─ auth/[...nextauth]/route.ts          # NextAuth handlers
 │  │  ├─ upload/route.ts                      # signed upload / server utilities
-│  │  └─ remove-bg/route.ts                   # optional server-side removal (alt to WASM)
+│  │  ├─ remove-bg/route.ts                   # optional server-side removal (alt to WASM)
+│  │  └─ design/route.ts                      # CRUD for editor persistence
 │  ├─ (editor)/page.tsx                       # main editor page
 │  ├─ layout.tsx
 │  └─ globals.css
@@ -144,7 +146,7 @@ pnpm dev
 * [ ] Add shadcn/ui primitives (Button, Slider, Dialog, Toast, Tooltip).
 * [ ] **Session header**: AuthButtons handles sign-in/out; avatar + menu pending.
 * [ ] Choose storage strategy (KV + Blob *or* Supabase) and implement abstraction.
-* [ ] Save/load **Design** documents per user.
+* [ ] Save/load **Design** documents per user (basic CRUD API present).
 * [ ] **Text layers** (Title/Subtitle) with clamp + balance (basic inputs exist).
 * [ ] **Background**: solid/gradient/image (with object‑fit cover, position).
 * [ ] **Layout presets**:  Add more, reset, auto-layout, auto fit

--- a/lib/editorStore.ts
+++ b/lib/editorStore.ts
@@ -3,7 +3,7 @@ import { persist } from 'zustand/middleware';
 import type { Preset } from './randomStyle';
 
 // State without actions for history snapshots
-interface EditorData {
+export interface EditorData {
   title: string;
   subtitle: string;
   titleFontSize: number;
@@ -68,6 +68,17 @@ const initialState: EditorData = {
   removeLogoBg: false,
   maskLogo: false,
   presets: [],
+};
+
+export const serializeEditorState = (state: EditorState | EditorData): string => {
+  const { logoFile, ...data } = state;
+  void logoFile;
+  return JSON.stringify(data);
+};
+
+export const deserializeEditorState = (json: string): EditorData => {
+  const data = JSON.parse(json) as Partial<EditorData>;
+  return { ...initialState, ...data };
 };
 
 export const useEditorStore = create<EditorState>()(


### PR DESCRIPTION
## Summary
- serialize editor state to JSON and restore it
- add `/api/design` CRUD endpoints for saved designs
- document persistence workflow and add tests

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm docs:guard`


------
https://chatgpt.com/codex/tasks/task_e_68adcb5c5918832b9d79d44143f840e8