### PR TITLE
feat: add balanced text inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,17 @@ pnpm dev
 ## Features
 - [x] Autenticação com Google e GitHub (NextAuth)
 - [ ] Provedores adicionais (Twitter, Facebook, Instagram)
-- [x] Editor com título, subtítulo e logo arrastável
+- [x] Editor com título, subtítulo e logo arrastável (texto balanceado e responsivo)
 - [x] Remoção de fundo, inversão B/W e máscara circular do logo
 - [ ] Upload de logo via drag-and-drop
 - [x] Exportação de PNG em múltiplos tamanhos
 - [ ] Presets automáticos de layout e cores
 
 ## How it works
-Projeto construído com **Next.js 15** (App Router) e **React 18**. Os estilos são gerenciados com **Tailwind CSS** e o estado global com **Zustand**.  
+Projeto construído com **Next.js 15** (App Router) e **React 18**. Os estilos são gerenciados com **Tailwind CSS** e o estado global com **Zustand**.
 A autenticacão é feita via **NextAuth** e a remoção de fundo usa um **WebWorker** com modelo WASM.
+
+Os textos de título e subtítulo utilizam CSS `clamp()` e `text-wrap: balance`, mantendo legibilidade em diferentes tamanhos.
 
 Estrutura principal:
 - `app/` – rotas e páginas (editor em `app/(editor)/page.tsx`)

--- a/__tests__/text-panel.test.tsx
+++ b/__tests__/text-panel.test.tsx
@@ -29,4 +29,14 @@ describe('TextPanel', () => {
     expect(state.titleFontSize).toBe(64);
     expect(state.subtitleFontSize).toBe(32);
   });
+
+  it('applies balanced wrapping and clamped font sizes', () => {
+    render(<TextPanel />);
+    const titleInput = screen.getByPlaceholderText('Your awesome title');
+    const subtitleInput = screen.getByPlaceholderText('Short description');
+    expect(titleInput).toHaveStyle('text-wrap: balance');
+    expect(titleInput).toHaveStyle('font-size: clamp(32px, 48px, 96px)');
+    expect(subtitleInput).toHaveStyle('text-wrap: balance');
+    expect(subtitleInput).toHaveStyle('font-size: clamp(16px, 24px, 48px)');
+  });
 });

--- a/components/editor/panels/TextPanel.tsx
+++ b/components/editor/panels/TextPanel.tsx
@@ -1,10 +1,59 @@
 "use client";
 import { useEditorStore } from "lib/editorStore";
+import type { ChangeEvent } from "react";
+import type { CSSProperties } from "react";
+
+type TextFieldProps = {
+  label: string;
+  placeholder: string;
+  value: string;
+  rows: number;
+  fontSize: number;
+  min: number;
+  max: number;
+  onChange: (value: string) => void;
+};
+
+function TextField({
+  label,
+  placeholder,
+  value,
+  rows,
+  fontSize,
+  min,
+  max,
+  onChange,
+}: TextFieldProps) {
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    onChange(e.target.value);
+  };
+
+  const style: CSSProperties & { textWrap?: string } = {
+    fontSize: `clamp(${min}px, ${fontSize}px, ${max}px)`,
+    textWrap: "balance",
+  };
+
+  return (
+    <label className="block">
+      <span className="text-sm">{label}</span>
+      <textarea
+        className="mt-1 w-full rounded-lg border bg-background px-3 py-2"
+        rows={rows}
+        placeholder={placeholder}
+        value={value}
+        onChange={handleChange}
+        style={style}
+      />
+    </label>
+  );
+}
 
 export default function TextPanel() {
   const {
     title,
     subtitle,
+    titleFontSize,
+    subtitleFontSize,
     setTitle,
     setSubtitle,
     setTitleFontSize,
@@ -23,25 +72,26 @@ export default function TextPanel() {
 
   return (
     <section className="space-y-3">
-      <label className="block">
-        <span className="text-sm">Title</span>
-        <input
-          className="mt-1 w-full rounded-lg border bg-background px-3 py-2"
-          placeholder="Your awesome title"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-        />
-      </label>
-      <label className="block">
-        <span className="text-sm">Subtitle</span>
-        <textarea
-          className="mt-1 w-full rounded-lg border bg-background px-3 py-2"
-          rows={3}
-          placeholder="Short description"
-          value={subtitle}
-          onChange={(e) => setSubtitle(e.target.value)}
-        />
-      </label>
+      <TextField
+        label="Title"
+        placeholder="Your awesome title"
+        value={title}
+        rows={2}
+        fontSize={titleFontSize}
+        min={32}
+        max={96}
+        onChange={setTitle}
+      />
+      <TextField
+        label="Subtitle"
+        placeholder="Short description"
+        value={subtitle}
+        rows={3}
+        fontSize={subtitleFontSize}
+        min={16}
+        max={48}
+        onChange={setSubtitle}
+      />
       <div className="grid grid-cols-3 gap-2">
         <button className="btn" aria-label="Extra small title size" onClick={() => applySize("xs")}>XS</button>
         <button className="btn" aria-label="Medium title size" onClick={() => applySize("md")}>MD</button>

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -89,7 +89,7 @@ OGGenerator is a one‑page (expandable) app to **compose Open Graph images** wi
 
 * Base size (1200×630). Zoom to fit viewport, render at 2× for crisp export.
 * 
-* Text: Title + Subtitle with smart clamp, max width, balance (`text-wrap: balance`).
+* Text: Title + Subtitle with smart clamp, max width, balance (`text-wrap: balance`) via reusable TextField components.
 * Layout Presets: horizontal left/center/right and vertical top/center/bottom alignment with 8px baseline.
 * Logo Layer: PNG/SVG upload (drag‑and‑drop + paste). Controls below.
 
@@ -145,7 +145,7 @@ pnpm dev
 * [ ] **Session header**: AuthButtons handles sign-in/out; avatar + menu pending.
 * [ ] Choose storage strategy (KV + Blob *or* Supabase) and implement abstraction.
 * [ ] Save/load **Design** documents per user.
-* [ ] **Text layers** (Title/Subtitle) with clamp + balance (basic inputs exist).
+* [x] **Text layers** (Title/Subtitle) with clamp + balance.
 * [ ] **Background**: solid/gradient/image (with object‑fit cover, position).
 * [ ] **Layout presets**:  Add more, reset, auto-layout, auto fit
 * [ ] **Resize on boundries**: Improve featur, it flicks when dragging close to border

--- a/docs/log/2025-08-30.md
+++ b/docs/log/2025-08-30.md
@@ -1,0 +1,10 @@
+# 2025-08-30
+
+## Summary
+- Implement balanced text components with CSS clamp and text-wrap balance.
+
+## Changed
+- components/editor/panels/TextPanel.tsx
+- __tests__/text-panel.test.tsx
+- README.md
+- docs/dev_doc.md


### PR DESCRIPTION
## Summary
- create reusable TextField with CSS clamp and text-wrap balance
- test text editing and clamped styles
- document balanced text usage

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm docs:guard`


------
https://chatgpt.com/codex/tasks/task_e_68adcb649188832baba9d3c2beb55ec7