### PR TITLE
feat: add background color controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ pnpm dev
 - [x] Remoção de fundo, inversão B/W e máscara circular do logo
 - [ ] Upload de logo via drag-and-drop
 - [x] Exportação de PNG em múltiplos tamanhos
+- [x] Cor de fundo personalizável
 - [ ] Presets automáticos de layout e cores
 
 ## How it works

--- a/__tests__/canvas-panel.test.tsx
+++ b/__tests__/canvas-panel.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import CanvasPanel from '../components/editor/panels/CanvasPanel';
+import { useEditorStore } from '../lib/editorStore';
+
+describe('CanvasPanel background', () => {
+  beforeEach(() => {
+    useEditorStore.getState().reset();
+  });
+
+  it('updates background color in the store', () => {
+    render(<CanvasPanel />);
+    const input = screen.getByLabelText('Background Color') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '#123456' } });
+    expect(useEditorStore.getState().background).toBe('#123456');
+  });
+});

--- a/__tests__/editor-store.test.ts
+++ b/__tests__/editor-store.test.ts
@@ -14,4 +14,9 @@ describe('editorStore position setters', () => {
     useEditorStore.getState().setSubtitlePosition(30, 40);
     expect(useEditorStore.getState().subtitlePosition).toEqual({ x: 30, y: 40 });
   });
+
+  it('updates background color', () => {
+    useEditorStore.getState().setBackground('#112233');
+    expect(useEditorStore.getState().background).toBe('#112233');
+  });
 });

--- a/__tests__/export-panel.test.tsx
+++ b/__tests__/export-panel.test.tsx
@@ -12,7 +12,7 @@ jest.mock('../lib/images', () => ({
 describe('ExportPanel', () => {
   beforeEach(() => {
     useEditorStore.getState().reset();
-    useEditorStore.setState({ title: 'T', subtitle: 'S' });
+    useEditorStore.setState({ title: 'T', subtitle: 'S', background: '#abcdef' });
     document.body.innerHTML = '<div id="og-canvas"></div>';
     Object.assign(navigator, { clipboard: { writeText: jest.fn().mockResolvedValue(undefined) } });
   });
@@ -24,7 +24,8 @@ describe('ExportPanel', () => {
     expect(mock).toHaveBeenCalledWith(
       document.getElementById('og-canvas'),
       { width: 1200, height: 630 },
-      'og-image-1200x630.png'
+      'og-image-1200x630.png',
+      { backgroundColor: '#abcdef' }
     );
   });
 
@@ -37,7 +38,8 @@ describe('ExportPanel', () => {
     expect(mock).toHaveBeenCalledWith(
       document.getElementById('og-canvas'),
       { width: 1600, height: 900 },
-      'og-image-1600x900.png'
+      'og-image-1600x900.png',
+      { backgroundColor: '#abcdef' }
     );
     expect(sizeBtn).toHaveAttribute('aria-pressed', 'true');
     expect(sizeBtn).toHaveClass('btn-primary');

--- a/components/CanvasStage.tsx
+++ b/components/CanvasStage.tsx
@@ -22,6 +22,7 @@ export default function CanvasStage() {
     theme,
     layout,
     accentColor,
+    background,
     bannerUrl,
     logoFile,
     logoUrl,
@@ -41,7 +42,7 @@ export default function CanvasStage() {
     removeLogoBg,
     invertLogo,
   });
-  const themeClasses = theme === 'dark' ? 'bg-gray-900 text-white' : 'bg-white text-gray-900';
+  const themeClasses = theme === 'dark' ? 'text-white' : 'text-gray-900';
   const textAlignClass =
     layout === 'center'
       ? 'text-center'
@@ -76,7 +77,8 @@ export default function CanvasStage() {
           height: BASE_HEIGHT,
           transform: `scale(${zoom})`,
           transformOrigin: 'top left',
-          borderColor: accentColor
+          borderColor: accentColor,
+          backgroundColor: background
         }}
       >
         {bannerSrc && (

--- a/components/editor/panels/CanvasPanel.tsx
+++ b/components/editor/panels/CanvasPanel.tsx
@@ -11,6 +11,8 @@ export default function CanvasPanel() {
     setVertical,
     accentColor,
     setAccentColor,
+    background,
+    setBackground,
   } = useEditorStore();
 
   return (
@@ -81,6 +83,17 @@ export default function CanvasPanel() {
           value={accentColor}
           onChange={(e) => setAccentColor(e.target.value)}
           aria-label="Accent Color"
+        />
+      </label>
+
+      <label className="block">
+        <span className="text-sm">Background</span>
+        <input
+          type="color"
+          className="mt-1 h-8 w-full rounded-lg border bg-background p-1"
+          value={background}
+          onChange={(e) => setBackground(e.target.value)}
+          aria-label="Background Color"
         />
       </label>
     </section>

--- a/components/editor/panels/ExportPanel.tsx
+++ b/components/editor/panels/ExportPanel.tsx
@@ -14,7 +14,7 @@ const SIZE_PRESETS: Record<string, ImageSize> = {
 
 export default function ExportPanel() {
   const [selected, setSelected] = useState<keyof typeof SIZE_PRESETS>("1200x630");
-  const { title, subtitle } = useEditorStore();
+  const { title, subtitle, background } = useEditorStore();
 
   const handleExport = async () => {
     const el = document.getElementById("og-canvas");
@@ -26,7 +26,8 @@ export default function ExportPanel() {
       await exportElementAsPng(
         el as HTMLElement,
         SIZE_PRESETS[selected],
-        `og-image-${selected}.png`
+        `og-image-${selected}.png`,
+        { backgroundColor: background }
       );
     } catch (err) {
       console.error(err);

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -88,10 +88,11 @@ OGGenerator is a one‑page (expandable) app to **compose Open Graph images** wi
 **Canvas Stage**
 
 * Base size (1200×630). Zoom to fit viewport, render at 2× for crisp export.
-* 
+*
 * Text: Title + Subtitle with smart clamp, max width, balance (`text-wrap: balance`).
 * Layout Presets: horizontal left/center/right and vertical top/center/bottom alignment with 8px baseline.
 * Logo Layer: PNG/SVG upload (drag‑and‑drop + paste). Controls below.
+* Background: solid color selection with undo/redo support.
 
 **Logo Controls**
 
@@ -146,7 +147,7 @@ pnpm dev
 * [ ] Choose storage strategy (KV + Blob *or* Supabase) and implement abstraction.
 * [ ] Save/load **Design** documents per user.
 * [ ] **Text layers** (Title/Subtitle) with clamp + balance (basic inputs exist).
-* [ ] **Background**: solid/gradient/image (with object‑fit cover, position).
+* [x] **Background**: solid color; gradient/image pending.
 * [ ] **Layout presets**:  Add more, reset, auto-layout, auto fit
 * [ ] **Resize on boundries**: Improve featur, it flicks when dragging close to border
 * [ ] **Remove Backgroun** processo lento, Mostrar loading.

--- a/lib/editorStore.ts
+++ b/lib/editorStore.ts
@@ -14,6 +14,7 @@ interface EditorData {
   layout: 'left' | 'center' | 'right';
   vertical: 'top' | 'center' | 'bottom';
   accentColor: string;
+  background: string;
   bannerUrl?: string;
   logoFile?: File;
   logoUrl?: string;
@@ -36,6 +37,7 @@ export interface EditorState extends EditorData {
   setLayout: (value: 'left' | 'center' | 'right') => void;
   setVertical: (value: 'top' | 'center' | 'bottom') => void;
   setAccentColor: (value: string) => void;
+  setBackground: (value: string) => void;
   setBannerUrl: (value: string | undefined) => void;
   setLogoFile: (file: File | undefined) => void;
   setLogoUrl: (url: string | undefined) => void;
@@ -62,6 +64,7 @@ const initialState: EditorData = {
   layout: 'left',
   vertical: 'center',
   accentColor: '#3b82f6',
+  background: '#ffffff',
   logoPosition: { x: 50, y: 50 },
   logoScale: 1,
   invertLogo: false,
@@ -87,6 +90,7 @@ export const useEditorStore = create<EditorState>()(
         layout,
         vertical,
         accentColor,
+        background,
         bannerUrl,
         logoFile,
         logoUrl,
@@ -107,6 +111,7 @@ export const useEditorStore = create<EditorState>()(
         layout,
         vertical,
         accentColor,
+        background,
         bannerUrl,
         logoFile,
         logoUrl,
@@ -137,6 +142,7 @@ export const useEditorStore = create<EditorState>()(
         setLayout: (value) => apply({ layout: value }),
         setVertical: (value) => apply({ vertical: value }),
         setAccentColor: (value) => apply({ accentColor: value }),
+        setBackground: (value) => apply({ background: value }),
         setBannerUrl: (value) => apply({ bannerUrl: value }),
         setLogoFile: (file) => apply({ logoFile: file, logoUrl: undefined }),
         setLogoUrl: (url) => apply({ logoUrl: url, logoFile: undefined }),
@@ -185,6 +191,7 @@ export const useEditorStore = create<EditorState>()(
         layout: state.layout,
         vertical: state.vertical,
         accentColor: state.accentColor,
+        background: state.background,
         bannerUrl: state.bannerUrl,
         logoUrl: state.logoUrl,
         logoPosition: state.logoPosition,

--- a/lib/images.ts
+++ b/lib/images.ts
@@ -14,13 +14,14 @@ export interface ImageSize {
  */
 export interface ExportOptions {
   pixelRatio?: number;
+  backgroundColor?: string;
 }
 
 export async function exportElementAsPng(
   element: HTMLElement,
   size: ImageSize,
   filename = 'og-image.png',
-  { pixelRatio = 1 }: ExportOptions = {}
+  { pixelRatio = 1, backgroundColor }: ExportOptions = {}
 ): Promise<void> {
   await document.fonts.ready;
 
@@ -40,7 +41,8 @@ export async function exportElementAsPng(
       width: `${originalWidth}px`,
       height: `${originalHeight}px`
     },
-    pixelRatio
+    pixelRatio,
+    backgroundColor
   });
 
   const link = document.createElement('a');


### PR DESCRIPTION
## Summary
- add persistent background color to editor store
- expose background picker in canvas settings
- include background color in PNG export

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm docs:guard`


------
https://chatgpt.com/codex/tasks/task_e_68adcb6a0014832b8bf6601f7332d945