### PR TITLE
feat: replace custom UI with shadcn primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pnpm dev
 - [ ] Presets automáticos de layout e cores
 
 ## How it works
-Projeto construído com **Next.js 15** (App Router) e **React 18**. Os estilos são gerenciados com **Tailwind CSS** e o estado global com **Zustand**.  
+Projeto construído com **Next.js 15** (App Router) e **React 18**. Os estilos são gerenciados com **Tailwind CSS** e os componentes básicos usam **shadcn/ui**; o estado global com **Zustand**.
 A autenticacão é feita via **NextAuth** e a remoção de fundo usa um **WebWorker** com modelo WASM.
 
 Estrutura principal:

--- a/__tests__/export-panel.test.tsx
+++ b/__tests__/export-panel.test.tsx
@@ -40,7 +40,6 @@ describe('ExportPanel', () => {
       'og-image-1600x900.png'
     );
     expect(sizeBtn).toHaveAttribute('aria-pressed', 'true');
-    expect(sizeBtn).toHaveClass('btn-primary');
   });
 
   it('copies meta tags', () => {

--- a/components/AuthButtons.tsx
+++ b/components/AuthButtons.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { signIn, signOut, useSession } from 'next-auth/react';
+import { Button } from '@/components/ui/button';
 
 /**
  * Renders sign in/out buttons based on the user's session state. When not
@@ -13,12 +14,7 @@ export default function AuthButtons() {
   if (status === 'loading') {
     return (
       <div className="space-x-3">
-        <button
-          type="button"
-          className="flex items-center justify-center rounded-md bg-gray-200 px-4 py-2 text-sm font-medium text-gray-700"
-          disabled
-          aria-busy="true"
-        >
+        <Button type="button" disabled aria-busy="true" variant="secondary" className="flex items-center justify-center px-4 py-2">
           <svg
             className="h-4 w-4 animate-spin"
             xmlns="http://www.w3.org/2000/svg"
@@ -41,7 +37,7 @@ export default function AuthButtons() {
             ></path>
           </svg>
           <span className="sr-only">Carregando</span>
-        </button>
+        </Button>
       </div>
     );
   }
@@ -51,20 +47,14 @@ export default function AuthButtons() {
       {session ? (
         <>
           <span className="text-sm font-medium">Olá, {session.user?.name || 'usuário'}</span>
-          <button
-            onClick={() => signOut()}
-            className="rounded-md bg-gray-200 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-300"
-          >
+          <Button onClick={() => signOut()} variant="secondary">
             Sair
-          </button>
+          </Button>
         </>
       ) : (
-        <button
-          onClick={() => signIn()}
-          className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
-        >
+        <Button onClick={() => signIn()}>
           Entrar
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/components/editor/Inspector.tsx
+++ b/components/editor/Inspector.tsx
@@ -6,6 +6,7 @@ import LogoPanel from "./panels/LogoPanel";
 import ExportPanel from "./panels/ExportPanel";
 import MetadataPanel from "./panels/MetadataPanel";
 import PresetsPanel from "./panels/PresetsPanel";
+import { Button } from "@/components/ui/button";
 
 const tabs = [
   { id: "canvas", label: "Canvas", component: CanvasPanel },
@@ -28,19 +29,18 @@ export default function Inspector() {
         aria-label="Editor panels"
       >
         {tabs.map(tab => (
-          <button
+          <Button
             key={tab.id}
             id={`tab-${tab.id}`}
             role="tab"
             aria-selected={active === tab.id}
             aria-controls={`panel-${tab.id}`}
-            className={`px-2 py-1 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring rounded-md ${
-              active === tab.id ? "border-b-2" : ""
-            }`}
+            variant={active === tab.id ? "secondary" : "ghost"}
+            size="sm"
             onClick={() => setActive(tab.id)}
           >
             {tab.label}
-          </button>
+          </Button>
         ))}
       </div>
       <div

--- a/components/editor/Toolbar.tsx
+++ b/components/editor/Toolbar.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect } from "react";
 import { useEditorStore } from "lib/editorStore";
 import { exportElementAsPng } from "lib/images";
 import { copyMetaTags } from "lib/meta";
+import { Button } from "@/components/ui/button";
 
 export default function Toolbar() {
   const {
@@ -66,48 +67,23 @@ export default function Toolbar() {
   return (
     <header className="flex items-center justify-between border-b bg-background/80 p-2 backdrop-blur">
       <div className="flex gap-2">
-        <button
-          className="btn"
-          aria-label="Undo"
-          title="Undo (Cmd/Ctrl+Z)"
-          onClick={handleUndo}
-        >
+        <Button aria-label="Undo" title="Undo (Cmd/Ctrl+Z)" onClick={handleUndo}>
           Undo
-        </button>
-        <button
-          className="btn"
-          aria-label="Redo"
-          title="Redo (Cmd/Ctrl+Shift+Z)"
-          onClick={handleRedo}
-        >
+        </Button>
+        <Button aria-label="Redo" title="Redo (Cmd/Ctrl+Shift+Z)" onClick={handleRedo}>
           Redo
-        </button>
+        </Button>
       </div>
       <div className="flex gap-2">
-        <button
-          className="btn"
-          aria-label="Copy Meta"
-          title="Copy Meta (Cmd/Ctrl+C)"
-          onClick={handleCopyMeta}
-        >
+        <Button aria-label="Copy Meta" title="Copy Meta (Cmd/Ctrl+C)" onClick={handleCopyMeta}>
           Copy Meta
-        </button>
-        <button
-          className="btn"
-          aria-label="Export"
-          title="Export"
-          onClick={handleExport}
-        >
+        </Button>
+        <Button aria-label="Export" title="Export" onClick={handleExport}>
           Export
-        </button>
-        <button
-          className="btn"
-          aria-label="Save"
-          title="Save (Cmd/Ctrl+S)"
-          onClick={handleSave}
-        >
+        </Button>
+        <Button aria-label="Save" title="Save (Cmd/Ctrl+S)" onClick={handleSave}>
           Save
-        </button>
+        </Button>
       </div>
     </header>
   );

--- a/components/editor/panels/ExportPanel.tsx
+++ b/components/editor/panels/ExportPanel.tsx
@@ -5,6 +5,7 @@ import { useEditorStore } from "lib/editorStore";
 import { exportElementAsPng, type ImageSize } from "lib/images";
 import { copyMetaTags } from "lib/meta";
 import { toast } from "components/ToastProvider";
+import { Button } from "@/components/ui/button";
 
 const SIZE_PRESETS: Record<string, ImageSize> = {
   "1200x630": { width: 1200, height: 630 },
@@ -46,35 +47,37 @@ export default function ExportPanel() {
   return (
     <section className="space-y-3">
       <div className="grid grid-cols-3 gap-2">
-        <button
-          className={`btn ${selected === "1200x630" ? "btn-primary" : ""}`}
+        <Button
+          variant={selected === "1200x630" ? "default" : "secondary"}
           aria-label="Export size 1200 by 630"
           aria-pressed={selected === "1200x630"}
           onClick={() => setSelected("1200x630")}
         >
           1200×630
-        </button>
-        <button
-          className={`btn ${selected === "1600x900" ? "btn-primary" : ""}`}
+        </Button>
+        <Button
+          variant={selected === "1600x900" ? "default" : "secondary"}
           aria-label="Export size 1600 by 900"
           aria-pressed={selected === "1600x900"}
           onClick={() => setSelected("1600x900")}
         >
           1600×900
-        </button>
-        <button
-          className={`btn ${selected === "1920x1005" ? "btn-primary" : ""}`}
+        </Button>
+        <Button
+          variant={selected === "1920x1005" ? "default" : "secondary"}
           aria-label="Export size 1920 by 1005"
           aria-pressed={selected === "1920x1005"}
           onClick={() => setSelected("1920x1005")}
         >
           1920×1005
-        </button>
+        </Button>
       </div>
-      <button className="btn btn-primary w-full" aria-label="Export image as PNG" onClick={handleExport}>
+      <Button className="w-full" aria-label="Export image as PNG" onClick={handleExport}>
         Export PNG
-      </button>
-      <button className="btn w-full" aria-label="Copy meta tags" onClick={handleCopyMeta}>Copy Meta</button>
+      </Button>
+      <Button className="w-full" variant="secondary" aria-label="Copy meta tags" onClick={handleCopyMeta}>
+        Copy Meta
+      </Button>
     </section>
   );
 }

--- a/components/editor/panels/LogoPanel.tsx
+++ b/components/editor/panels/LogoPanel.tsx
@@ -1,6 +1,8 @@
 "use client";
 import { useEditorStore } from "lib/editorStore";
 import type { ChangeEvent } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 
 export default function LogoPanel() {
   const {
@@ -69,27 +71,26 @@ export default function LogoPanel() {
           aria-label="Upload logo file"
           className="hidden"
         />
-        <label htmlFor="logo-upload" className="btn">
-          Choose File
-        </label>
-        <button className="btn" aria-label="Paste logo from clipboard" onClick={handlePaste}>
+        <Button asChild variant="secondary">
+          <label htmlFor="logo-upload">Choose File</label>
+        </Button>
+        <Button aria-label="Paste logo from clipboard" onClick={handlePaste}>
           Paste
-        </button>
-        <button className="btn" aria-label="Load logo from URL" onClick={handleUrl}>
+        </Button>
+        <Button aria-label="Load logo from URL" onClick={handleUrl}>
           From URL
-        </button>
+        </Button>
       </div>
       <div className="grid grid-cols-3 gap-2">
-        <button className="btn" aria-label="Remove background from logo" onClick={toggleRemoveLogoBg}>
+        <Button aria-label="Remove background from logo" onClick={toggleRemoveLogoBg}>
           Remove BG
-        </button>
-        <button className="btn" aria-label="Invert logo colors" onClick={toggleInvertLogo}>
+        </Button>
+        <Button aria-label="Invert logo colors" onClick={toggleInvertLogo}>
           Invert B/W
-        </button>
-        <button className="btn" aria-label="Mask logo as circle" onClick={toggleMaskLogo}>
-
+        </Button>
+        <Button aria-label="Mask logo as circle" onClick={toggleMaskLogo}>
           Mask: Circle
-        </button>
+        </Button>
       </div>
       <div>
         <label htmlFor="logo-scale" className="text-sm">
@@ -111,7 +112,7 @@ export default function LogoPanel() {
           <label htmlFor="logo-x" className="text-sm">
             X
           </label>
-          <input
+          <Input
             id="logo-x"
             type="number"
             min={0}
@@ -125,7 +126,7 @@ export default function LogoPanel() {
           <label htmlFor="logo-y" className="text-sm">
             Y
           </label>
-          <input
+          <Input
             id="logo-y"
             type="number"
             min={0}
@@ -171,9 +172,9 @@ export default function LogoPanel() {
         />
       </div>
       <div>
-        <button className="btn" aria-label="Reset logo adjustments" onClick={handleReset}>
+        <Button aria-label="Reset logo adjustments" onClick={handleReset}>
           Reset
-        </button>
+        </Button>
       </div>
     </section>
   );

--- a/components/editor/panels/MetadataPanel.tsx
+++ b/components/editor/panels/MetadataPanel.tsx
@@ -4,6 +4,9 @@ import { useState } from 'react';
 import { useMetadataStore } from 'lib/metadataStore';
 import { useEditorStore } from 'lib/editorStore';
 import { toast } from 'components/ToastProvider';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
 
 /**
  * Panel for editing metadata related to the current Open Graph image. By
@@ -63,72 +66,67 @@ export default function MetadataPanel() {
           URL
         </label>
         <div className="mt-1 flex gap-2">
-          <input
+          <Input
             id="url"
             type="url"
             value={url}
             onChange={(e) => setUrl(e.target.value)}
-            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
             placeholder="https://exemplo.com"
           />
-          <button
-            type="button"
-            onClick={handleFetch}
-            className="rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700"
-          >
+          <Button type="button" onClick={handleFetch}>
             Fetch metadata
-          </button>
+          </Button>
         </div>
       </div>
       <div>
         <label className="block text-sm font-medium text-gray-700" htmlFor="siteName">
           Nome do site
         </label>
-        <input
+        <Input
           id="siteName"
           type="text"
           value={siteName}
           onChange={(e) => setSiteName(e.target.value)}
-          className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
           placeholder="Nome do site"
+          className="mt-1"
         />
       </div>
       <div>
         <label className="block text-sm font-medium text-gray-700" htmlFor="description">
           Descrição
         </label>
-        <textarea
+        <Textarea
           id="description"
           value={description}
           onChange={(e) => setDescription(e.target.value)}
-          className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
           placeholder="Descrição da página"
+          className="mt-1"
         />
       </div>
       <div>
         <label className="block text-sm font-medium text-gray-700" htmlFor="image">
           URL da imagem
         </label>
-        <input
+        <Input
           id="image"
           type="url"
           value={image}
           onChange={(e) => setImage(e.target.value)}
-          className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
           placeholder="https://exemplo.com/imagem.png"
+          className="mt-1"
         />
       </div>
       <div>
         <label className="block text-sm font-medium text-gray-700" htmlFor="favicon">
           URL do favicon
         </label>
-        <input
+        <Input
           id="favicon"
           type="url"
           value={favicon}
           onChange={(e) => setFavicon(e.target.value)}
-          className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
           placeholder="https://exemplo.com/favicon.ico"
+          className="mt-1"
         />
       </div>
       {warnings.length > 0 && (

--- a/components/editor/panels/PresetsPanel.tsx
+++ b/components/editor/panels/PresetsPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useEditorStore } from 'lib/editorStore';
 import { generateRandomPreset } from 'lib/randomStyle';
+import { Button } from '@/components/ui/button';
 
 /**
  * Panel that allows creating random style presets and applying them.
@@ -20,18 +21,16 @@ export default function PresetsPanel() {
   return (
     <div className="space-y-4">
       <h2 className="text-lg font-semibold">Presets</h2>
-      <button
-        onClick={handleGeneratePreset}
-        className="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
-      >
+      <Button onClick={handleGeneratePreset}>
         Gerar Preset Aleatório
-      </button>
+      </Button>
       <ul className="space-y-2">
         {presets.map((preset, index) => (
           <li key={index}>
-            <button
+            <Button
               onClick={() => applyPreset(preset)}
-              className="flex w-full items-center justify-between rounded-md border px-2 py-1 text-left hover:bg-gray-50"
+              variant="secondary"
+              className="flex w-full items-center justify-between px-2 py-1 text-left"
             >
               <span className="text-sm">
                 {preset.theme} / {preset.layout}
@@ -40,7 +39,7 @@ export default function PresetsPanel() {
                 className="h-4 w-4 rounded"
                 style={{ backgroundColor: preset.accentColor }}
               />
-            </button>
+            </Button>
           </li>
         ))}
         {presets.length === 0 && (

--- a/components/editor/panels/TextPanel.tsx
+++ b/components/editor/panels/TextPanel.tsx
@@ -1,5 +1,8 @@
 "use client";
 import { useEditorStore } from "lib/editorStore";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
 
 export default function TextPanel() {
   const {
@@ -25,8 +28,8 @@ export default function TextPanel() {
     <section className="space-y-3">
       <label className="block">
         <span className="text-sm">Title</span>
-        <input
-          className="mt-1 w-full rounded-lg border bg-background px-3 py-2"
+        <Input
+          className="mt-1"
           placeholder="Your awesome title"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
@@ -34,8 +37,8 @@ export default function TextPanel() {
       </label>
       <label className="block">
         <span className="text-sm">Subtitle</span>
-        <textarea
-          className="mt-1 w-full rounded-lg border bg-background px-3 py-2"
+        <Textarea
+          className="mt-1"
           rows={3}
           placeholder="Short description"
           value={subtitle}
@@ -43,9 +46,15 @@ export default function TextPanel() {
         />
       </label>
       <div className="grid grid-cols-3 gap-2">
-        <button className="btn" aria-label="Extra small title size" onClick={() => applySize("xs")}>XS</button>
-        <button className="btn" aria-label="Medium title size" onClick={() => applySize("md")}>MD</button>
-        <button className="btn" aria-label="Extra large title size" onClick={() => applySize("xl")}>XL</button>
+        <Button aria-label="Extra small title size" onClick={() => applySize("xs")}>
+          XS
+        </Button>
+        <Button aria-label="Medium title size" onClick={() => applySize("md")}>
+          MD
+        </Button>
+        <Button aria-label="Extra large title size" onClick={() => applySize("xl")}>
+          XL
+        </Button>
       </div>
     </section>
   );

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,53 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,24 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,23 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Textarea.displayName = "Textarea"
+
+export { Textarea }

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -15,7 +15,7 @@ OGGenerator is a one‑page (expandable) app to **compose Open Graph images** wi
 ## 2) Tech Stack
 
 * **Framework:** Next.js (React, App Router) — SPA feel + API routes for auth and utilities.
-* **Styling:** TailwindCSS + shadcn/ui (optional) for primitives (Toasts, Dialog, Slider).
+* **Styling:** TailwindCSS + shadcn/ui for primitives (Button, Input, Textarea).
 * **Auth:** NextAuth.js (Auth.js) with OAuth providers (see configuration below).
 * **Storage:**
   * Local state: Zustand with undo/redo history and localStorage persistence.
@@ -46,6 +46,10 @@ OGGenerator is a one‑page (expandable) app to **compose Open Graph images** wi
 │  ├─ ErrorBoundary.tsx
 │  ├─ Providers.tsx
 │  ├─ ToastProvider.tsx
+│  ├─ ui/
+│  │  ├─ button.tsx
+│  │  ├─ input.tsx
+│  │  └─ textarea.tsx
 │  └─ editor/
 │     ├─ EditorShell.tsx
 │     ├─ Inspector.tsx
@@ -62,6 +66,7 @@ OGGenerator is a one‑page (expandable) app to **compose Open Graph images** wi
 │  ├─ meta.ts                                  # build OG/Twitter meta tags
 │  ├─ randomStyle.ts
 │  ├─ removeBg.ts                              # WASM loader + pipeline
+│  ├─ utils.ts                                 # className helper
 │  └─ hooks/
 │     └─ useProcessedLogo.ts                   # prepares logo image (BG removal + inversion)
 ├─ state/
@@ -111,7 +116,6 @@ OGGenerator is a one‑page (expandable) app to **compose Open Graph images** wi
 
 ```
 pnpm i
-pnpm dlx shadcn-ui@latest init   # optional UI kit
 pnpm dev
 ```
 
@@ -141,7 +145,7 @@ pnpm dev
 
 ## 13) TODO
 
-* [ ] Add shadcn/ui primitives (Button, Slider, Dialog, Toast, Tooltip).
+* [ ] Add remaining shadcn/ui primitives (Slider, Dialog, Toast, Tooltip). Button/Input/Textarea integrated.
 * [ ] **Session header**: AuthButtons handles sign-in/out; avatar + menu pending.
 * [ ] Choose storage strategy (KV + Blob *or* Supabase) and implement abstraction.
 * [ ] Save/load **Design** documents per user.

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/package.json
+++ b/package.json
@@ -14,8 +14,11 @@
   "dependencies": {
     "@imgly/background-removal": "^1.7.0",
     "@odeconto/scraper": "^0.1.20",
+    "@radix-ui/react-slot": "^1.2.3",
     "@tailwindcss/forms": "^0.5.10",
     "autoprefixer": "^10.4.14",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "html-to-image": "^1.11.13",
     "next": "15.5.0",
     "next-auth": "^4.24.11",
@@ -23,6 +26,7 @@
     "postcss": "^8.4.23",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "tailwind-merge": "^3.3.1",
     "tailwindcss": "^3.3.5",
     "zod": "^4.1.1",
     "zustand": "^4.4.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,21 @@ importers:
       '@odeconto/scraper':
         specifier: ^0.1.20
         version: 0.1.20
+      '@radix-ui/react-slot':
+        specifier: ^1.2.3
+        version: 1.2.3(@types/react@18.3.24)(react@18.3.1)
       '@tailwindcss/forms':
         specifier: ^0.5.10
         version: 0.5.10(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2)))
       autoprefixer:
         specifier: ^10.4.14
         version: 10.4.21(postcss@8.5.6)
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       html-to-image:
         specifier: ^1.11.13
         version: 1.11.13
@@ -41,6 +50,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
+      tailwind-merge:
+        specifier: ^3.3.1
+        version: 3.3.1
       tailwindcss:
         specifier: ^3.3.5
         version: 3.4.17(ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2))
@@ -902,6 +914,24 @@ packages:
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -1427,12 +1457,19 @@ packages:
   cjs-module-lexer@2.1.0:
     resolution: {integrity: sha512-UX0OwmYRYQQetfrLEZeewIFFI+wSTofC+pMBLNuH3RUuu/xzG1oz84UCEDOSoQlN3fZ4+AzmV50ZYvGqkMh9yA==}
 
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
@@ -3160,6 +3197,9 @@ packages:
     resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
+  tailwind-merge@3.3.1:
+    resolution: {integrity: sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==}
+
   tailwindcss@3.4.17:
     resolution: {integrity: sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==}
     engines: {node: '>=14.0.0'}
@@ -4241,6 +4281,19 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@18.3.24)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.24
+
+  '@radix-ui/react-slot@1.2.3(@types/react@18.3.24)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.24)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.24
+
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.12.0': {}
@@ -4842,6 +4895,10 @@ snapshots:
 
   cjs-module-lexer@2.1.0: {}
 
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
+
   client-only@0.0.1: {}
 
   cliui@8.0.1:
@@ -4849,6 +4906,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  clsx@2.1.1: {}
 
   co@4.6.0: {}
 
@@ -7002,6 +7061,8 @@ snapshots:
   synckit@0.11.11:
     dependencies:
       '@pkgr/core': 0.2.9
+
+  tailwind-merge@3.3.1: {}
 
   tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2)):
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,9 @@
       "next-auth",
       "@types/node"
     ],
+    "paths": {
+      "@/*": ["./*"]
+    },
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Summary
- add shadcn button, input and textarea components
- swap ad-hoc buttons/inputs in editor and auth flow
- document shadcn usage in README and developer docs

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm docs:guard`


------
https://chatgpt.com/codex/tasks/task_e_68adcb46618c832ba23bc87bed64fe40