### PR TITLE
feat: add toast hooks and toolbar feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ pnpm dev
 - [x] Remoção de fundo, inversão B/W e máscara circular do logo (com loading)
 - [ ] Upload de logo via drag-and-drop
 - [x] Exportação de PNG em múltiplos tamanhos
+- [x] Toasts para salvar, exportar e erros
 - [x] Cor de fundo personalizável
 - [ ] Presets automáticos de layout e cores
 - [x] API de persistência do editor (CRUD)

--- a/__tests__/toolbar.test.tsx
+++ b/__tests__/toolbar.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import Toolbar from '../components/editor/Toolbar';
+import { toast } from '../components/ToastProvider';
+
+jest.mock('../components/ToastProvider', () => {
+  const toast = jest.fn();
+  return {
+    toast,
+    useToast: () => ({
+      save: (msg = 'Saved') => toast({ message: msg }),
+      exportImage: (msg = 'Exported') => toast({ message: msg }),
+      error: (msg = 'Unexpected error') => toast({ message: msg, variant: 'error' }),
+    }),
+  };
+});
+
+const mockAddPreset = jest.fn();
+
+jest.mock('../lib/editorStore', () => ({
+  useEditorStore: jest.fn((selector) =>
+    selector({
+      undo: jest.fn(),
+      redo: jest.fn(),
+      addPreset: mockAddPreset,
+      theme: 'light',
+      layout: 'left',
+      accentColor: '#000',
+      title: 't',
+      subtitle: 's',
+    })
+  ),
+}));
+
+jest.mock('../lib/images', () => ({
+  exportElementAsPng: jest.fn(),
+}));
+
+jest.mock('../lib/meta', () => ({
+  copyMetaTags: jest.fn(),
+}));
+
+describe('Toolbar toasts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows toast on save', () => {
+    render(<Toolbar />);
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    expect(toast).toHaveBeenCalledWith({ message: 'Saved' });
+  });
+
+  it('shows toast on export success', async () => {
+    const { exportElementAsPng } = require('../lib/images');
+    exportElementAsPng.mockResolvedValue(undefined);
+    document.body.innerHTML = '<div id="og-canvas"></div>';
+    render(<Toolbar />);
+    fireEvent.click(screen.getByRole('button', { name: /export/i }));
+    await waitFor(() => expect(toast).toHaveBeenCalledWith({ message: 'Exported' }));
+  });
+
+  it('shows error toast on export failure', async () => {
+    const { exportElementAsPng } = require('../lib/images');
+    exportElementAsPng.mockRejectedValue(new Error('fail'));
+    document.body.innerHTML = '<div id="og-canvas"></div>';
+    render(<Toolbar />);
+    fireEvent.click(screen.getByRole('button', { name: /export/i }));
+    await waitFor(() =>
+      expect(toast).toHaveBeenCalledWith({
+        message: 'Failed to export image',
+        variant: 'error',
+      })
+    );
+  });
+});

--- a/components/ToastProvider.tsx
+++ b/components/ToastProvider.tsx
@@ -15,6 +15,15 @@ export function toast(opts: { message: string; variant?: "default" | "error" }) 
   }
 }
 
+export function useToast() {
+  return {
+    save: (message = "Saved") => toast({ message }),
+    exportImage: (message = "Exported") => toast({ message }),
+    error: (message = "Unexpected error") =>
+      toast({ message, variant: "error" }),
+  };
+}
+
 export default function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<Toast[]>([]);
 

--- a/components/editor/Toolbar.tsx
+++ b/components/editor/Toolbar.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect } from "react";
 import { useEditorStore } from "lib/editorStore";
 import { exportElementAsPng } from "lib/images";
 import { copyMetaTags } from "lib/meta";
+import { useToast } from "components/ToastProvider";
 import { Button } from "@/components/ui/button";
 
 export default function Toolbar() {
@@ -17,6 +18,8 @@ export default function Toolbar() {
     title,
     subtitle,
   } = useEditorStore();
+  const { save: toastSave, exportImage: toastExport, error: toastError } =
+    useToast();
 
   const handleUndo = useCallback(() => undo(), [undo]);
   const handleRedo = useCallback(() => redo(), [redo]);
@@ -32,13 +35,16 @@ export default function Toolbar() {
     if (!element) return;
     try {
       await exportElementAsPng(element, { width: 1200, height: 630 });
+      toastExport();
     } catch (err) {
+      toastError("Failed to export image");
       console.error(err);
     }
-  }, []);
+  }, [toastExport, toastError]);
   const handleSave = useCallback(() => {
     addPreset({ theme, layout, accentColor });
-  }, [addPreset, theme, layout, accentColor]);
+    toastSave();
+  }, [addPreset, theme, layout, accentColor, toastSave]);
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -167,7 +167,7 @@ pnpm dev
 ## 18) Error Handling
 
 * `ErrorBoundary` envolve o `EditorShell` exibindo um fallback amigável.
-* `ToastProvider` fornece notificações para falhas em remoção de fundo, exportação e busca de metadata.
+* `ToastProvider` expõe `useToast` com mensagens padrão de salvar, exportar e erros em remoção de fundo ou busca de metadata.
 
 ---
 


### PR DESCRIPTION
## Summary
- add `useToast` helpers for save/export/error
- show toast feedback for toolbar save and export actions
- document toast hooks and cover toolbar toasts with tests

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ELIFECYCLE Test failed)*
- `pnpm docs:guard`


------
https://chatgpt.com/codex/tasks/task_e_68add4b26bb0832b8a5ff252557893f2