### PR TITLE
fix: guard export when document.fonts missing

### DIFF
--- a/__tests__/images.test.ts
+++ b/__tests__/images.test.ts
@@ -8,6 +8,9 @@ jest.mock('html-to-image', () => ({
 
 afterEach(() => {
   jest.restoreAllMocks();
+  // ensure document.fonts doesn't leak across tests
+  // @ts-ignore
+  delete document.fonts;
 });
 
 describe('image utilities', () => {
@@ -180,6 +183,17 @@ describe('image utilities', () => {
         element,
         expect.objectContaining({ pixelRatio: 2 })
       );
+    });
+
+    it('exports even if document.fonts is missing', async () => {
+      const element = document.createElement('div');
+      Object.defineProperty(element, 'clientWidth', { value: 100 });
+      Object.defineProperty(element, 'clientHeight', { value: 50 });
+
+      await exportElementAsPng(element, { width: 200, height: 100 }, 'test.png');
+
+      const toPngMock = htmlToImage.toPng as jest.Mock;
+      expect(toPngMock).toHaveBeenCalled();
     });
 
     it('ignores bounding box transforms when scaling for export', async () => {

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -191,3 +191,11 @@ Context: Needed accessible tooltips and visible focus styles for editor controls
 Decision: Added shadcn/ui Tooltip primitive and audited interactive elements with focus-visible ring styling.
 Consequences: Improved keyboard navigation and discoverability of actions; future components should reuse these patterns.
 Links: PR TBD
+
+# Guard font readiness in exportElementAsPng
+Date: 2025-08-26
+Status: accepted
+Context: `document.fonts` may be undefined in some environments, causing export to fail.
+Decision: Check for the Fonts API before awaiting `document.fonts.ready` when exporting images.
+Consequences: Ensures PNG export works in browsers lacking `document.fonts` support.
+Links: PR TBD

--- a/lib/images.ts
+++ b/lib/images.ts
@@ -23,7 +23,9 @@ export async function exportElementAsPng(
   filename = 'og-image.png',
   { pixelRatio = 1, backgroundColor }: ExportOptions = {}
 ): Promise<void> {
-  await document.fonts.ready;
+  if ('fonts' in document) {
+    await (document as any).fonts.ready;
+  }
 
   // Use client dimensions so preview zoom transforms do not affect export.
   const originalWidth = element.clientWidth;


### PR DESCRIPTION
## Summary
- guard `exportElementAsPng` when the Fonts API isn't available
- test exporting without `document.fonts`
- document font readiness decision

## Testing
- `pnpm docs:guard`
- `pnpm test` *(fails: Cannot find module '@radix-ui/react-slot' from 'components/ui/button.tsx')*
- `pnpm test __tests__/images.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68add970f560832ba4a47ed090e4f928