### PR TITLE
fix: avoid empty logo src in CanvasStage

### DIFF
--- a/__tests__/canvas-stage.test.tsx
+++ b/__tests__/canvas-stage.test.tsx
@@ -22,6 +22,11 @@ describe('CanvasStage', () => {
     expect(banners[0].getAttribute('src')).toContain('banner.png');
   });
 
+  it('does not render a logo when none is provided', () => {
+    render(<CanvasStage />);
+    expect(screen.queryByAltText('Logo')).toBeNull();
+  });
+
   it('uses dimensions from store', () => {
     useEditorStore.setState({ width: 1600, height: 900 });
     render(<CanvasStage />);

--- a/components/CanvasStage.tsx
+++ b/components/CanvasStage.tsx
@@ -38,7 +38,7 @@ export default function CanvasStage() {
     height,
   } = useEditorStore();
   const { containerRef, zoom } = useCanvasZoom(width, height);
-  const logoDataUrl = useProcessedLogo({
+  const { logoDataUrl } = useProcessedLogo({
     logoFile,
     logoUrl,
     removeLogoBg,
@@ -131,7 +131,7 @@ export default function CanvasStage() {
             baseHeight={height}
           >
             <Image
-              src={logoDataUrl.logoDataUrl}
+              src={logoDataUrl}
               alt="Logo"
               width={96}
               height={96}

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -199,3 +199,11 @@ Context: `document.fonts` may be undefined in some environments, causing export 
 Decision: Check for the Fonts API before awaiting `document.fonts.ready` when exporting images.
 Consequences: Ensures PNG export works in browsers lacking `document.fonts` support.
 Links: PR TBD
+
+# Avoid empty logo src in CanvasStage
+Date: 2025-08-26
+Status: accepted
+Context: Next.js warned when the logo `<Image>` rendered with an empty `src`.
+Decision: Destructure `useProcessedLogo` and render the logo only when a data URL exists.
+Consequences: Eliminates spurious image requests and console errors.
+Links: PR TBD


### PR DESCRIPTION
## Summary
- prevent CanvasStage from passing empty src to logo image
- add regression test for missing logo
- document CanvasStage logo src handling

## Testing
- `pnpm test` *(fails: Cannot find module '@radix-ui/react-slot' from 'components/ui/button.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_68addaf90958832baeb0a16c80d76d99