### PR TITLE
Remove Draggable edge deformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pnpm dev
 - [x] Avatar e menu de sessão persistente
 - [ ] Provedores adicionais (Twitter, Facebook, Instagram)
 - [x] Remoção de fundo, inversão B/W e máscara circular do logo
-- [x] Editor com título, subtítulo e logo arrastável
+- [x] Editor com título, subtítulo e logo arrastável (posicionamento limitado sem deformar)
 - [x] Remoção de fundo, inversão B/W e máscara circular do logo (com loading)
 - [ ] Upload de logo via drag-and-drop
 - [x] Exportação de PNG em múltiplos tamanhos

--- a/__tests__/canvas-drag.test.tsx
+++ b/__tests__/canvas-drag.test.tsx
@@ -1,7 +1,7 @@
 import { render, fireEvent, screen } from '@testing-library/react';
 import CanvasStage from '../components/CanvasStage';
 import { useEditorStore } from '../lib/editorStore';
-import { waitFor } from '@testing-library/react';
+import { BASE_WIDTH, BASE_HEIGHT } from '../components/Draggable';
 
 describe('CanvasStage drag', () => {
   beforeAll(() => {
@@ -42,41 +42,19 @@ describe('CanvasStage drag', () => {
     Object.defineProperty(wrapper, 'offsetWidth', { value: 96 });
     Object.defineProperty(wrapper, 'offsetHeight', { value: 96 });
 
+    const halfWidthPct = (96 / BASE_WIDTH) * 50;
+    const halfHeightPct = (96 / BASE_HEIGHT) * 50;
+
     fireEvent.pointerDown(wrapper, { clientX: 50, clientY: 50 });
     fireEvent.pointerMove(wrapper, { clientX: -1000, clientY: -1000 });
     let pos = useEditorStore.getState().logoPosition;
-    expect(pos.x).toBeCloseTo(4, 1);
-    expect(pos.y).toBeCloseTo(7.6, 1);
+    expect(pos.x).toBeCloseTo(halfWidthPct, 1);
+    expect(pos.y).toBeCloseTo(halfHeightPct, 1);
     fireEvent.pointerMove(wrapper, { clientX: 2000, clientY: 2000 });
     pos = useEditorStore.getState().logoPosition;
-    expect(pos.x).toBeCloseTo(99.2, 1);
-    expect(pos.y).toBeCloseTo(98.48, 1);
+    expect(pos.x).toBeCloseTo(100 - halfWidthPct, 1);
+    expect(pos.y).toBeCloseTo(100 - halfHeightPct, 1);
     fireEvent.pointerUp(wrapper, { clientX: 2000, clientY: 2000 });
   });
 
-  const getScale = (el: HTMLElement) => {
-    const match = el.style.transform.match(/scale\(([^)]+)\)/);
-    return match ? parseFloat(match[1]) : 1;
-  };
-
-  it('deforms near edges and restores after release', async () => {
-    render(<CanvasStage />);
-    const logo = screen.getByAltText('Logo');
-    const wrapper = logo.parentElement as HTMLElement;
-    Object.defineProperty(wrapper, 'offsetWidth', { value: 96 });
-    Object.defineProperty(wrapper, 'offsetHeight', { value: 96 });
-
-    fireEvent.pointerDown(wrapper, { clientX: 50, clientY: 50 });
-    fireEvent.pointerMove(wrapper, { clientX: -1000, clientY: 50 });
-
-    await waitFor(() => {
-      expect(getScale(wrapper)).toBeLessThan(1);
-    });
-
-    fireEvent.pointerUp(wrapper, { clientX: -1000, clientY: 50 });
-
-    await waitFor(() => {
-      expect(getScale(wrapper)).toBeCloseTo(1);
-    });
-  });
 });

--- a/__tests__/draggable.test.tsx
+++ b/__tests__/draggable.test.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import Draggable, { BASE_WIDTH, BASE_HEIGHT } from '../components/Draggable';
 
 describe('Draggable', () => {
@@ -28,35 +28,6 @@ describe('Draggable', () => {
     expect(y).not.toBe(50);
   });
 
-  const getScale = (el: HTMLElement) => {
-    const match = el.style.transform.match(/scale\(([^)]+)\)/);
-    return match ? parseFloat(match[1]) : 1;
-  };
-
-  it('deforms near edges and restores after release', async () => {
-    const onChange = jest.fn();
-    render(
-      <Draggable position={{ x: 50, y: 50 }} onChange={onChange} zoom={1}>
-        <div data-testid="content" />
-      </Draggable>
-    );
-    const wrapper = screen.getByTestId('content').parentElement as HTMLElement;
-    Object.defineProperty(wrapper, 'offsetWidth', { value: 96 });
-    Object.defineProperty(wrapper, 'offsetHeight', { value: 96 });
-
-    fireEvent.pointerDown(wrapper, { clientX: 50, clientY: 50 });
-    fireEvent.pointerMove(wrapper, { clientX: -1000, clientY: 50 });
-
-    await waitFor(() => {
-      expect(getScale(wrapper)).toBeLessThan(1);
-    });
-
-    fireEvent.pointerUp(wrapper, { clientX: -1000, clientY: 50 });
-
-    await waitFor(() => {
-      expect(getScale(wrapper)).toBeCloseTo(1);
-    });
-  });
 
   it('clamps position within canvas bounds', () => {
     const onChange = jest.fn();

--- a/__tests__/toolbar.test.tsx
+++ b/__tests__/toolbar.test.tsx
@@ -17,8 +17,8 @@ jest.mock('../components/ToastProvider', () => {
 const mockAddPreset = jest.fn();
 
 jest.mock('../lib/editorStore', () => ({
-  useEditorStore: jest.fn((selector) =>
-    selector({
+  useEditorStore: jest.fn((selector?: any) => {
+    const state = {
       undo: jest.fn(),
       redo: jest.fn(),
       addPreset: mockAddPreset,
@@ -27,8 +27,9 @@ jest.mock('../lib/editorStore', () => ({
       accentColor: '#000',
       title: 't',
       subtitle: 's',
-    })
-  ),
+    };
+    return selector ? selector(state) : state;
+  }),
 }));
 
 jest.mock('../lib/images', () => ({

--- a/components/Draggable.tsx
+++ b/components/Draggable.tsx
@@ -29,8 +29,7 @@ export default function Draggable({
       }
     | null
   >(null);
-  const [deform, setDeform] = useState(1);
-  const DEFORM_THRESHOLD = 5;
+  // Element scale remains constant; previous edge-deformation logic removed
 
   const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     e.preventDefault();
@@ -46,9 +45,8 @@ export default function Draggable({
     const dx = e.clientX - start.pointer.x;
     const dy = e.clientY - start.pointer.y;
     const el = e.currentTarget as HTMLElement;
-    const currentScale = scale * deform;
-    const width = el.offsetWidth * currentScale;
-    const height = el.offsetHeight * currentScale;
+    const width = el.offsetWidth * scale;
+    const height = el.offsetHeight * scale;
     const halfWidthPct = (width / baseWidth) * 50;
     const halfHeightPct = (height / baseHeight) * 50;
     const nx = start.origin.x + (dx / (baseWidth * zoom)) * 100;
@@ -58,22 +56,11 @@ export default function Draggable({
     const x = clamp(nx, Math.min(halfWidthPct, 100 - halfWidthPct), Math.max(halfWidthPct, 100 - halfWidthPct));
     const y = clamp(ny, Math.min(halfHeightPct, 100 - halfHeightPct), Math.max(halfHeightPct, 100 - halfHeightPct));
 
-
-    const distLeft = x - halfWidthPct;
-    const distRight = 100 - (x + halfWidthPct);
-    const distTop = y - halfHeightPct;
-    const distBottom = 100 - (y + halfHeightPct);
-    const minDist = Math.min(distLeft, distRight, distTop, distBottom);
-    const nextDeform =
-      minDist < DEFORM_THRESHOLD ? Math.max(minDist / DEFORM_THRESHOLD, 0.2) : 1;
-
-    setDeform(nextDeform);
     onChange(x, y);
   };
 
   const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
     setStart(null);
-    setDeform(1);
     (e.currentTarget as HTMLElement).releasePointerCapture?.(e.pointerId);
   };
 
@@ -83,7 +70,7 @@ export default function Draggable({
       style={{
         top: `${position.y}%`,
         left: `${position.x}%`,
-        transform: `translate(-50%, -50%) scale(${scale * deform})`,
+        transform: `translate(-50%, -50%) scale(${scale})`,
       }}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -99,7 +99,7 @@ OGGenerator is a one‑page (expandable) app to **compose Open Graph images** wi
 
 **Logo Controls**
 
-* **Translate**: click‑drag in canvas with positions clamped to bounds; fine‑tune with arrow keys (Shift = 10×).
+* **Translate**: click‑drag in canvas with positions clamped to bounds; fine‑tune with arrow keys (Shift = 10×). Element scale remains constant near edges.
 * **Scale**: pinch/scroll over logo; numeric slider with min/max.
 * **Manual Position**: X/Y number inputs in Logo panel update with drag.
 * **Remove Background**: client‑side WASM U^2‑Net; fallback API route.
@@ -147,7 +147,7 @@ pnpm dev
 * [ ] Choose storage strategy (KV + Blob *or* Supabase) and implement abstraction.
 * [ ] Save/load **Design** documents per user.
 * [ ] **Layout presets**:  Add more, reset, auto-layout, auto fit
-* [ ] **Resize on boundries**: Improve featur, it flicks when dragging close to border
+* [ ] **Edge feedback**: add visual indicator when dragging near boundaries (deformation removed)
 * [x] **Remove Backgroun** processo lento, Mostrar loading.
 * [ ] **Invert B/W** improve.
 * [ ] Hi‑DPI export (2× then downscale) to PNG.
@@ -206,4 +206,12 @@ Status: accepted
 Context: Next.js warned when the logo `<Image>` rendered with an empty `src`.
 Decision: Destructure `useProcessedLogo` and render the logo only when a data URL exists.
 Consequences: Eliminates spurious image requests and console errors.
+Links: PR TBD
+
+# Drop edge deformation in Draggable
+Date: 2025-08-26
+Status: accepted
+Context: Scaling the logo near canvas edges caused visual distortion and conflicted with position clamping.
+Decision: Remove deformation logic; keep position clamping so the logo stays fully visible.
+Consequences: Simplifies drag behavior; consider adding a different edge indicator later.
 Links: PR TBD

--- a/docs/log/2025-08-31.md
+++ b/docs/log/2025-08-31.md
@@ -1,0 +1,11 @@
+# 2025-08-31
+
+## Summary
+- Remove logo deformation near canvas edges and rely solely on position clamping.
+
+## Changed
+- components/Draggable.tsx
+- __tests__/draggable.test.tsx
+- __tests__/canvas-drag.test.tsx
+- docs/dev_doc.md
+- README.md

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -4,5 +4,5 @@ import React from 'react'
 
 jest.mock('next/image', () => ({
   __esModule: true,
-  default: (props: any) => React.createElement('img', props),
+  default: (props: React.ComponentProps<'img'>) => React.createElement('img', props),
 }))

--- a/lib/images.ts
+++ b/lib/images.ts
@@ -24,7 +24,7 @@ export async function exportElementAsPng(
   { pixelRatio = 1, backgroundColor }: ExportOptions = {}
 ): Promise<void> {
   if ('fonts' in document) {
-    await (document as any).fonts.ready;
+    await (document.fonts as FontFaceSet).ready;
   }
 
   // Use client dimensions so preview zoom transforms do not affect export.


### PR DESCRIPTION
## Summary
- keep draggable elements at constant scale and clamp positions to canvas
- document removal of drag deformation
- adjust tests and mocks for new behavior

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm docs:guard`


------
https://chatgpt.com/codex/tasks/task_e_68addd543c88832babf314c4b0c1447f