### PR TITLE
Proxy remote logos before background removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ pnpm dev
 ## How it works
 Projeto construído com **Next.js 15** (App Router) e **React 18**. Os estilos são gerenciados com **Tailwind CSS** e o estado global com **Zustand**.
 A autenticacão é feita via **NextAuth**, a remoção de fundo usa um **WebWorker** com modelo WASM e o estado do editor pode ser serializado e salvo em `/api/design`.
+Imagens externas são carregadas via `/api/image` para contornar restrições de CORS antes de qualquer processamento.
 
 
 Os textos de título e subtítulo utilizam CSS `clamp()` e `text-wrap: balance`, mantendo legibilidade em diferentes tamanhos.
@@ -92,7 +93,7 @@ Os testes residem em `__tests__/` e cobrem utilitários e fluxos principais.
 
 ## Known Issues
 - Alguns sites bloqueiam a coleta de metadados; nesse caso o painel de Metadata exibe um toast de erro.
-- A exportação falha se a origem da imagem não permitir CORS, mesmo com `crossOrigin="anonymous"`.
+- Alguns hosts podem bloquear requisições feitas pelo proxy `/api/image`, resultando em falha na remoção de fundo.
 
 ## Licença
 Projeto licenciado sob MIT. Consulte [LICENSE](LICENSE) para mais detalhes.

--- a/__tests__/useProcessedLogo.test.ts
+++ b/__tests__/useProcessedLogo.test.ts
@@ -27,7 +27,10 @@ describe('useProcessedLogo', () => {
   });
 
   it('removes background when enabled', async () => {
-    (removeImageBackground as jest.Mock).mockResolvedValue('removed-url');
+    (removeImageBackground as jest.Mock).mockResolvedValue('data-removed-url');
+    (ensureSameOriginImage as jest.Mock).mockImplementation((url: string) =>
+      url === 'logo.png' ? 'proxied-logo.png' : url,
+    );
     const { result } = renderHook(() =>
       useProcessedLogo({
         logoUrl: 'logo.png',
@@ -37,9 +40,11 @@ describe('useProcessedLogo', () => {
       })
     );
     await waitFor(() => expect(result.current.loading).toBe(true));
-    await waitFor(() => expect(result.current.logoDataUrl).toBe('removed-url'));
+    await waitFor(() => expect(result.current.logoDataUrl).toBe('data-removed-url'));
     expect(result.current.loading).toBe(false);
-    expect(removeImageBackground).toHaveBeenCalledWith('logo.png');
+    expect(removeImageBackground).toHaveBeenCalledWith('proxied-logo.png');
+    expect(ensureSameOriginImage).toHaveBeenNthCalledWith(1, 'logo.png');
+    expect(ensureSameOriginImage).toHaveBeenNthCalledWith(2, 'data-removed-url');
   });
 
   it('inverts colors when enabled', async () => {

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -215,3 +215,11 @@ Context: Scaling the logo near canvas edges caused visual distortion and conflic
 Decision: Remove deformation logic; keep position clamping so the logo stays fully visible.
 Consequences: Simplifies drag behavior; consider adding a different edge indicator later.
 Links: PR TBD
+
+# Proxy remote images for background removal
+Date: 2025-08-27
+Status: accepted
+Context: `removeBackground` failed on third-party logos due to CORS restrictions.
+Decision: Normalize URLs via `ensureSameOriginImage` before invoking `removeImageBackground`.
+Consequences: Background removal works for external logos through the `/api/image` proxy with minimal overhead.
+Links: PR TBD

--- a/lib/hooks/useProcessedLogo.ts
+++ b/lib/hooks/useProcessedLogo.ts
@@ -35,7 +35,9 @@ export default function useProcessedLogo({
 
       try {
         if (removeLogoBg) {
-          source = await removeImageBackground(source);
+          const prepared =
+            source instanceof Blob ? source : ensureSameOriginImage(source)!;
+          source = await removeImageBackground(prepared);
         }
 
         let normalized: string;


### PR DESCRIPTION
## Summary
- normalize remote logo URLs through `/api/image` before invoking background removal
- note proxy behavior and potential failures in docs
- add regression test for proxied logos

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm docs:guard`


------
https://chatgpt.com/codex/tasks/task_e_68adde648108832b8d6cd6fb486e932d