### PR TITLE
Commit drag state to undo history only on release

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ pnpm dev
 - [x] Remoção de fundo, inversão B/W e máscara circular do logo
 - [x] Editor com título, subtítulo e logo arrastável (posicionamento limitado sem deformar)
 - [x] Remoção de fundo, inversão B/W e máscara circular do logo (com loading)
+- [x] Histórico de undo/redo para edições
 - [ ] Upload de logo via drag-and-drop
 - [x] Exportação de PNG em múltiplos tamanhos
 - [x] Toasts para salvar, exportar e erros

--- a/__tests__/canvas-drag.test.tsx
+++ b/__tests__/canvas-drag.test.tsx
@@ -57,4 +57,21 @@ describe('CanvasStage drag', () => {
     fireEvent.pointerUp(wrapper, { clientX: 2000, clientY: 2000 });
   });
 
+  it('saves a single history entry on drag release', () => {
+    render(<CanvasStage />);
+    const logo = screen.getByAltText('Logo');
+    const wrapper = logo.parentElement as HTMLElement;
+
+    fireEvent.pointerDown(wrapper, { clientX: 100, clientY: 100 });
+    fireEvent.pointerMove(wrapper, { clientX: 160, clientY: 130 });
+    fireEvent.pointerMove(wrapper, { clientX: 200, clientY: 160 });
+    fireEvent.pointerUp(wrapper, { clientX: 200, clientY: 160 });
+
+    const afterDrag = useEditorStore.getState().logoPosition;
+    expect(afterDrag.x).toBeGreaterThan(50);
+
+    useEditorStore.getState().undo();
+    const undone = useEditorStore.getState().logoPosition;
+    expect(undone).toEqual({ x: 50, y: 50 });
+  });
 });

--- a/__tests__/draggable.test.tsx
+++ b/__tests__/draggable.test.tsx
@@ -22,10 +22,13 @@ describe('Draggable', () => {
     fireEvent.pointerMove(wrapper, { clientX: 160, clientY: 130 });
     fireEvent.pointerUp(wrapper, { clientX: 160, clientY: 130 });
 
-    expect(onChange).toHaveBeenCalled();
-    const [x, y] = onChange.mock.calls[0];
-    expect(x).not.toBe(50);
-    expect(y).not.toBe(50);
+    expect(onChange).toHaveBeenCalledTimes(2);
+    const first = onChange.mock.calls[0] as [number, number, boolean];
+    const second = onChange.mock.calls[1] as [number, number, boolean];
+    expect(first[2]).toBe(true);
+    expect(second[2]).toBe(false);
+    expect(second[0]).not.toBe(50);
+    expect(second[1]).not.toBe(50);
   });
 
 

--- a/components/Draggable.tsx
+++ b/components/Draggable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type ReactNode } from 'react';
+import { useState, useRef, type ReactNode } from 'react';
 
 export const BASE_WIDTH = 1200;
 export const BASE_HEIGHT = 630;
@@ -15,7 +15,7 @@ export default function Draggable({
   baseHeight = BASE_HEIGHT,
 }: {
   position: { x: number; y: number };
-  onChange: (x: number, y: number) => void;
+  onChange: (x: number, y: number, commit?: boolean) => void;
   scale?: number;
   zoom: number;
   children: ReactNode;
@@ -37,8 +37,12 @@ export default function Draggable({
       pointer: { x: e.clientX, y: e.clientY },
       origin: { x: position.x, y: position.y },
     });
+    last.current = { x: position.x, y: position.y };
+    onChange(position.x, position.y, true);
     (e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId);
   };
+
+  const last = useRef<{ x: number; y: number }>({ x: position.x, y: position.y });
 
   const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
     if (!start) return;
@@ -56,7 +60,8 @@ export default function Draggable({
     const x = clamp(nx, Math.min(halfWidthPct, 100 - halfWidthPct), Math.max(halfWidthPct, 100 - halfWidthPct));
     const y = clamp(ny, Math.min(halfHeightPct, 100 - halfHeightPct), Math.max(halfHeightPct, 100 - halfHeightPct));
 
-    onChange(x, y);
+    last.current = { x, y };
+    onChange(x, y, false);
   };
 
   const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -99,7 +99,7 @@ OGGenerator is a one‑page (expandable) app to **compose Open Graph images** wi
 
 **Logo Controls**
 
-* **Translate**: click‑drag in canvas with positions clamped to bounds; fine‑tune with arrow keys (Shift = 10×). Element scale remains constant near edges.
+* **Translate**: click‑drag in canvas with positions clamped to bounds; fine‑tune with arrow keys (Shift = 10×). Element scale remains constant near edges. Undo history commits once on release.
 * **Scale**: pinch/scroll over logo; numeric slider with min/max.
 * **Manual Position**: X/Y number inputs in Logo panel update with drag.
 * **Remove Background**: client‑side WASM U^2‑Net; fallback API route.

--- a/docs/log/2025-08-26.md
+++ b/docs/log/2025-08-26.md
@@ -44,6 +44,18 @@
 # 2025-08-26
 
 ## Summary
+- Record undo history for draggable elements only on release to prevent stack spam.
+
+## Changed
+- lib/editorStore.ts
+- components/Draggable.tsx
+- lib/hooks/useLogoKeyboardControls.ts
+- __tests__/canvas-drag.test.tsx
+- docs/dev_doc.md
+- README.md
+# 2025-08-26
+
+## Summary
 - feat: add meta tag builder and copy export
 
 ## Changed

--- a/lib/editorStore.ts
+++ b/lib/editorStore.ts
@@ -33,8 +33,8 @@ export interface EditorState extends EditorData {
   setSubtitle: (value: string) => void;
   setTitleFontSize: (size: number) => void;
   setSubtitleFontSize: (size: number) => void;
-  setTitlePosition: (x: number, y: number) => void;
-  setSubtitlePosition: (x: number, y: number) => void;
+  setTitlePosition: (x: number, y: number, commit?: boolean) => void;
+  setSubtitlePosition: (x: number, y: number, commit?: boolean) => void;
   setTheme: (value: 'light' | 'dark') => void;
   setLayout: (value: 'left' | 'center' | 'right') => void;
   setVertical: (value: 'top' | 'center' | 'bottom') => void;
@@ -43,7 +43,7 @@ export interface EditorState extends EditorData {
   setBannerUrl: (value: string | undefined) => void;
   setLogoFile: (file: File | undefined) => void;
   setLogoUrl: (url: string | undefined) => void;
-  setLogoPosition: (x: number, y: number) => void;
+  setLogoPosition: (x: number, y: number, commit?: boolean) => void;
   setLogoScale: (scale: number) => void;
   toggleInvertLogo: () => void;
   toggleRemoveLogoBg: () => void;
@@ -143,6 +143,9 @@ export const useEditorStore = create<EditorState>()(
         presets,
       });
 
+      const patch = (partial: Partial<EditorData>) =>
+        set((state) => ({ ...state, ...partial }));
+
       const apply = (partial: Partial<EditorData>) =>
         set((state) => {
           past.push(stripActions(state));
@@ -156,8 +159,10 @@ export const useEditorStore = create<EditorState>()(
         setSubtitle: (value) => apply({ subtitle: value }),
         setTitleFontSize: (size) => apply({ titleFontSize: size }),
         setSubtitleFontSize: (size) => apply({ subtitleFontSize: size }),
-        setTitlePosition: (x, y) => apply({ titlePosition: { x, y } }),
-        setSubtitlePosition: (x, y) => apply({ subtitlePosition: { x, y } }),
+        setTitlePosition: (x, y, commit = true) =>
+          (commit ? apply : patch)({ titlePosition: { x, y } }),
+        setSubtitlePosition: (x, y, commit = true) =>
+          (commit ? apply : patch)({ subtitlePosition: { x, y } }),
         setTheme: (value) => apply({ theme: value }),
         setLayout: (value) => apply({ layout: value }),
         setVertical: (value) => apply({ vertical: value }),
@@ -167,7 +172,8 @@ export const useEditorStore = create<EditorState>()(
         setBannerUrl: (value) => apply({ bannerUrl: value }),
         setLogoFile: (file) => apply({ logoFile: file, logoUrl: undefined }),
         setLogoUrl: (url) => apply({ logoUrl: url, logoFile: undefined }),
-        setLogoPosition: (x, y) => apply({ logoPosition: { x, y } }),
+        setLogoPosition: (x, y, commit = true) =>
+          (commit ? apply : patch)({ logoPosition: { x, y } }),
         setLogoScale: (scale) => apply({ logoScale: scale }),
         toggleInvertLogo: () => apply({ invertLogo: !get().invertLogo }),
         toggleRemoveLogoBg: () => apply({ removeLogoBg: !get().removeLogoBg }),

--- a/lib/hooks/useLogoKeyboardControls.ts
+++ b/lib/hooks/useLogoKeyboardControls.ts
@@ -4,7 +4,7 @@ interface LogoKeyboardControls {
   logoScale: number;
   logoPosition: { x: number; y: number };
   setLogoScale: (scale: number) => void;
-  setLogoPosition: (x: number, y: number) => void;
+  setLogoPosition: (x: number, y: number, commit?: boolean) => void;
 }
 
 export function useLogoKeyboardControls({


### PR DESCRIPTION
## Summary
- avoid pushing undo state on every drag frame
- add regression test for drag history
- document single-step undo behavior and enable undo/redo feature in README

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm docs:guard`


------
https://chatgpt.com/codex/tasks/task_e_68addffcf5bc832b846990d509ee4e77