### PR TITLE
docs: tidy readme and dev guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Requisitos: Node.js 18+ e pnpm.
 
 ```bash
 pnpm install
-cp .env.local.example .env.local  # preencha com suas credenciais
+cp .env.example .env.local  # preencha com suas credenciais
 pnpm dev
 # acesse http://localhost:3000
 ```
@@ -17,7 +17,6 @@ pnpm dev
 - [x] Autenticação com Google e GitHub (NextAuth)
 - [x] Avatar e menu de sessão persistente
 - [ ] Provedores adicionais (Twitter, Facebook, Instagram)
-- [x] Remoção de fundo, inversão B/W e máscara circular do logo
 - [x] Editor com título, subtítulo e logo arrastável (posicionamento limitado aos quatro lados, sem deformar)
 - [x] Remoção de fundo, inversão B/W e máscara circular do logo (com loading)
 - [x] Histórico de undo/redo para edições
@@ -53,10 +52,10 @@ Estrutura principal:
 - **Shift+Setas para cima/baixo**: redimensionar o logo
 
 ## Env Vars
-Copie o arquivo `.env.local.example` para `.env.local` e preencha as chaves:
+Copie o arquivo `.env.example` para `.env.local` e preencha as chaves:
 
 ```bash
-cp .env.local.example .env.local
+cp .env.example .env.local
 ```
 
 Defina um `NEXTAUTH_SECRET` forte e configure credenciais dos provedores OAuth desejados. Variáveis opcionais (Twitter, Facebook, Instagram) omitem os botões de login se ausentes.  
@@ -69,6 +68,9 @@ NEXTAUTH_SECRET=seu-segredo
 GOOGLE_CLIENT_ID=...
 GOOGLE_CLIENT_SECRET=...
 ```
+
+## Documentation
+Consulte [docs/dev_doc.md](docs/dev_doc.md) para detalhes de arquitetura e [docs/log](docs/log) para o histórico de decisões.
 
 ## Testing
 Execute os testes unitários e verifique se a documentação está sincronizada:

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -9,7 +9,11 @@ A concise, implementation‑ready base for the **OG Image Studio** project using
 OGGenerator is a one‑page (expandable) app to **compose Open Graph images** with live preview and export presets. Users authenticate via mainstream providers and can **upload a logo** and **edit it** (translate, scale, remove background, invert B/W). The result is exportable as PNG and the app can copy a ready‑to‑paste meta‑tag block.
 
 **MVP Goals**
-
+* Autenticação com Google e GitHub via NextAuth.
+* Editor de canvas com logo arrastável, undo/redo e presets de dimensão.
+* Upload e processamento do logo (remoção de fundo, inversão B/W, máscara).
+* Exportação de PNG com tamanhos predefinidos.
+* Persistência de designs via API e armazenamento.
 ---
 
 ## 2) Tech Stack
@@ -80,7 +84,7 @@ OGGenerator is a one‑page (expandable) app to **compose Open Graph images** wi
 │  └─ index.d.ts
 ├─ public/
 │  └─ fonts/*
-├─ .env.local.example
+├─ .env.example
 ├─ tailwind.config.ts
 ├─ postcss.config.js
 ├─ next.config.js
@@ -116,6 +120,7 @@ OGGenerator is a one‑page (expandable) app to **compose Open Graph images** wi
 
 ```
 pnpm i
+cp .env.example .env.local
 pnpm dev
 ```
 


### PR DESCRIPTION
## Summary
- fix env example filename in Quickstart and Env Vars sections
- add documentation links and MVP goals
- document env setup in dev guide

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm docs:guard`


------
https://chatgpt.com/codex/tasks/task_e_68ade7b3444c832ba58b4b9228a88876