### PR TITLE
test: silence warnings and mock next image

### DIFF
--- a/__tests__/ErrorBoundary.test.tsx
+++ b/__tests__/ErrorBoundary.test.tsx
@@ -12,6 +12,7 @@ function Boom() {
 }
 
 test('renders fallback on error', () => {
+  const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
   render(
     <ErrorBoundary fallback={<div>fallback</div>}>
       <Boom />
@@ -19,4 +20,5 @@ test('renders fallback on error', () => {
   );
   expect(screen.getByText('fallback')).toBeInTheDocument();
   expect(toast).toHaveBeenCalled();
+  spy.mockRestore();
 });

--- a/__tests__/canvas-drag.test.tsx
+++ b/__tests__/canvas-drag.test.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent, screen } from '@testing-library/react';
+import { act, render, fireEvent, screen } from '@testing-library/react';
 import CanvasStage from '../components/CanvasStage';
 import { useEditorStore } from '../lib/editorStore';
 import { BASE_WIDTH, BASE_HEIGHT } from '../components/Draggable';
@@ -9,11 +9,13 @@ describe('CanvasStage drag', () => {
     (window as any).PointerEvent = MouseEvent;
   });
   beforeEach(() => {
-    useEditorStore.getState().reset();
-    useEditorStore.setState({
-      logoUrl: 'https://example.com/logo.png',
-      logoPosition: { x: 50, y: 50 },
-      logoScale: 1,
+    act(() => {
+      useEditorStore.getState().reset();
+      useEditorStore.setState({
+        logoUrl: 'https://example.com/logo.png',
+        logoPosition: { x: 50, y: 50 },
+        logoScale: 1,
+      });
     });
   });
 
@@ -70,7 +72,9 @@ describe('CanvasStage drag', () => {
     const afterDrag = useEditorStore.getState().logoPosition;
     expect(afterDrag.x).toBeGreaterThan(50);
 
-    useEditorStore.getState().undo();
+    act(() => {
+      useEditorStore.getState().undo();
+    });
     const undone = useEditorStore.getState().logoPosition;
     expect(undone).toEqual({ x: 50, y: 50 });
   });

--- a/__tests__/toolbar-shortcuts.test.tsx
+++ b/__tests__/toolbar-shortcuts.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import Toolbar from '../components/editor/Toolbar';
 import { useEditorStore } from '../lib/editorStore';
 import { buildMetaTags } from '../lib/meta';
@@ -17,7 +17,9 @@ describe('Toolbar shortcuts', () => {
     logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     writeText = jest.fn().mockResolvedValue(undefined);
     Object.assign(navigator, { clipboard: { writeText } });
-    useEditorStore.getState().reset();
+    act(() => {
+      useEditorStore.getState().reset();
+    });
   });
 
   afterEach(() => {
@@ -26,33 +28,43 @@ describe('Toolbar shortcuts', () => {
   });
 
   it('handles undo via click and shortcut', () => {
-    useEditorStore.getState().setTitle('initial');
-    useEditorStore.getState().setTitle('changed');
+    act(() => {
+      useEditorStore.getState().setTitle('initial');
+      useEditorStore.getState().setTitle('changed');
+    });
     render(<Toolbar />);
     fireEvent.click(screen.getByRole('button', { name: 'Undo' }));
     expect(useEditorStore.getState().title).toBe('initial');
-    useEditorStore.getState().setTitle('changed');
+    act(() => {
+      useEditorStore.getState().setTitle('changed');
+    });
     fireEvent.keyDown(window, { key: 'z', ctrlKey: true });
     expect(useEditorStore.getState().title).toBe('initial');
   });
 
   it('handles redo via click and shortcut', () => {
-    useEditorStore.getState().setTitle('initial');
-    useEditorStore.getState().setTitle('changed');
+    act(() => {
+      useEditorStore.getState().setTitle('initial');
+      useEditorStore.getState().setTitle('changed');
+    });
     render(<Toolbar />);
     fireEvent.click(screen.getByRole('button', { name: 'Undo' }));
     fireEvent.click(screen.getByRole('button', { name: 'Redo' }));
     expect(useEditorStore.getState().title).toBe('changed');
-    useEditorStore.getState().setTitle('initial');
-    useEditorStore.getState().setTitle('changed');
+    act(() => {
+      useEditorStore.getState().setTitle('initial');
+      useEditorStore.getState().setTitle('changed');
+    });
     fireEvent.keyDown(window, { key: 'z', ctrlKey: true });
     fireEvent.keyDown(window, { key: 'Z', ctrlKey: true, shiftKey: true });
     expect(useEditorStore.getState().title).toBe('changed');
   });
 
   it('handles copy meta via click and shortcut', async () => {
-    useEditorStore.getState().setTitle('My Title');
-    useEditorStore.getState().setSubtitle('My Desc');
+    act(() => {
+      useEditorStore.getState().setTitle('My Title');
+      useEditorStore.getState().setSubtitle('My Desc');
+    });
     render(<Toolbar />);
     const expected = buildMetaTags({ title: 'My Title', description: 'My Desc' });
     fireEvent.click(screen.getByRole('button', { name: 'Copy Meta' }));

--- a/__tests__/toolbar.test.tsx
+++ b/__tests__/toolbar.test.tsx
@@ -43,6 +43,11 @@ jest.mock('../lib/meta', () => ({
 describe('Toolbar toasts', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    (console.error as jest.Mock).mockRestore();
   });
 
   it('shows toast on save', () => {

--- a/docs/dev_doc.md
+++ b/docs/dev_doc.md
@@ -230,3 +230,19 @@ Context: Right-edge clamping was explicit but other sides relied on implicit beh
 Decision: Compute explicit min/max percentages for both axes and clamp against all four canvas edges.
 Consequences: Dragging stops uniformly at each boundary without visual scaling.
 Links: PR TBD
+
+# Strip boolean props in next/image mock
+Date: 2025-09-10
+Status: accepted
+Context: Jest tests mocked `next/image` with a plain `<img>` element, causing React to warn about `fill` and `unoptimized` boolean attributes.
+Decision: Filter Next.js-specific boolean props from the mock before rendering the `<img>`.
+Consequences: Test runs no longer emit React attribute warnings, keeping logs clean.
+Links: PR TBD
+
+# Wrap Zustand mutations in tests with act
+Date: 2025-09-10
+Status: accepted
+Context: Direct calls to `useEditorStore` setters during tests triggered React warnings about updates outside `act`.
+Decision: Wrap store mutations in `act()` within affected tests.
+Consequences: Ensures state changes are flushed before assertions and eliminates noisy warnings.
+Links: PR TBD

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -4,5 +4,10 @@ import React from 'react'
 
 jest.mock('next/image', () => ({
   __esModule: true,
-  default: (props: React.ComponentProps<'img'>) => React.createElement('img', props),
-}))
+  default: (props: React.ComponentProps<'img'>) => {
+    const rest = { ...props } as Record<string, unknown>;
+    delete rest.fill;
+    delete rest.unoptimized;
+    return React.createElement('img', rest);
+  },
+}));


### PR DESCRIPTION
## Summary
- strip `fill` and `unoptimized` before rendering the `next/image` mock
- wrap zustand mutations with `act` in CanvasStage and Toolbar tests
- silence console errors in toolbar and error boundary tests
- document testing decisions in dev docs

## Testing
- `pnpm lint`
- `pnpm docs:guard`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68ade9b34d98832bab09dfb30143d8e3